### PR TITLE
Removed ss3 commands from protocol.hpp

### DIFF
--- a/include/terminalpp/ansi/protocol.hpp
+++ b/include/terminalpp/ansi/protocol.hpp
@@ -16,12 +16,6 @@ namespace terminalpp { namespace ansi {
 // Single Character Functions and other supporting characters
 static char const PS = terminalpp::ascii::SEMI_COLON; // Parameter Separator
 
-namespace ss3 {
-    // specific control codes for Single Shift Select of character set G3
-    static char const HOME = terminalpp::ascii::UPPERCASE_H;
-    static char const END  = terminalpp::ascii::UPPERCASE_F;
-}
-
 }}
 
 


### PR DESCRIPTION
ss3::HOME and ss3::END are already present as ss3::CURSOR_HOME and
ss3::CURSOR_END in ss3.hpp.  These appear to have been left over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/103)
<!-- Reviewable:end -->
