### PR TITLE
Included cstddef in core.hpp

### DIFF
--- a/include/terminalpp/core.hpp
+++ b/include/terminalpp/core.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "terminalpp/detail/export.hpp"
+#include <cstddef>
 #include <boost/cstdint.hpp>
 
 namespace terminalpp {


### PR DESCRIPTION
With some library/compiler combinations, including a standard library
causes a clash with max_align_t, which is only present in cstddef. This
minor change helps avoid that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/146)
<!-- Reviewable:end -->
