### PR TITLE
Package trusty version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 export.hpp
+version.hpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,105 +4,153 @@ sudo: false
 compiler:
   - clang
 
-env:
-  - CONFIG=Release SHARED=1 CCOMPILE=clang CXXCOMPILE=clang++
-  - CONFIG=Release SHARED=0 CCOMPILE=clang CXXCOMPILE=clang++
-  - CONFIG=Debug SHARED=1 CCOMPILE=clang CXXCOMPILE=clang++
-  - CONFIG=Debug SHARED=0 CCOMPILE=clang CXXCOMPILE=clang++
-  - CONFIG=Debug SHARED=0 CCOMPILE=clang CXXCOMPILE=clang++ SANITIZE=address
-#  - CONFIG=Debug SHARED=0 CCOMPILE=clang CXXCOMPILE=clang++ SANITIZE=thread
-  - CONFIG=Debug SHARED=0 CCOMPILE=clang CXXCOMPILE=clang++ SANITIZE=undefined
-
-addons:
-  apt:
-    sources: &sources
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - clang
-      - gcc-4.8
-      - g++-4.8
-      - libgtest-dev
-      - libboost1.55-all-dev
-
 matrix:
   include:
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-5
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Debug && SHARED=0 && COVERAGE=ON"
 
-    # g++-5.2 with coverage
-    - compiler: g++
-      env: CONFIG=Debug SHARED=0 CCOMPILE=gcc-5 CXXCOMPILE=g++-5 COVERAGE=ON
-      addons:
-        apt:
-          sources: *sources
-          packages:
-            - gcc-5
-            - g++-5
-            - libgtest-dev
-            - libboost1.55-all-dev
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-5
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Debug && SHARED=1"
 
-    # g++-5.2
-    - compiler: g++
-      env: CONFIG=Release SHARED=1 CCOMPILE=gcc-5 CXXCOMPILE=g++-5
-      addons:
-        apt:
-          sources: *sources
-          packages:
-            - clang
-            - gcc-5
-            - g++-5
-            - libgtest-dev
-            - libboost1.55-all-dev
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-5
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Release && SHARED=0"
 
-    - compiler: g++
-      env: CONFIG=Release SHARED=0 CCOMPILE=gcc-5 CXXCOMPILE=g++-5
-      addons:
-        apt:
-          sources: *sources
-          packages:
-            - clang
-            - gcc-5
-            - g++-5
-            - libgtest-dev
-            - libboost1.55-all-dev
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-5
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Release && SHARED=1"
 
-    - compiler: g++
-      env: CONFIG=Debug SHARED=1 CCOMPILE=gcc-5 CXXCOMPILE=g++-5
-      addons:
-        apt:
-          sources: *sources
-          packages:
-            - clang
-            - gcc-5
-            - g++-5
-            - libgtest-dev
-            - libboost1.55-all-dev
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=0"
 
-    - compiler: g++
-      env: CONFIG=Debug SHARED=0 CCOMPILE=gcc-5 CXXCOMPILE=g++-5
-      addons:
-        apt:
-          sources: *sources
-          packages:
-            - clang
-            - gcc-5
-            - g++-5
-            - libgtest-dev
-            - libboost1.55-all-dev
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=1"
 
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=0 && SANITIZE=address"
+
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=0 && SANITIZE=undefined"
+
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=0 && SANITIZE=thread"
+
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-4.0
+        packages:
+          - clang-4.0
+          - libgtest-dev
+          - libboost1.55-all-dev
+    env:
+      - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0 && CONFIG=Debug && SHARED=0"
 cache:
   - apt: true
   - directories:
-    - cmake-3.4.0-Linux-x86_64
     - lcov
     - gtest
 
 before_install:
-# workaround for not having CMake 3.2
-  - if [ ! -d "cmake-3.4.0-Linux-x86_64/bin" ]; then
-      wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.tar.gz;
-      tar -xzf cmake-3.4.0-Linux-x86_64.tar.gz;
-    fi
-  - export CMAKE=../cmake-3.4.0-Linux-x86_64/bin/cmake
+# Set up CC/CXX variables
+  - eval "${MATRIX_EVAL}"
+  - export CMAKE=cmake
 # workaround for not having lcov 1.13
   - if [ ! -d "lcov/usr/local/bin/lcov" ]; then
       wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.13.orig.tar.gz;
@@ -124,7 +172,7 @@ before_install:
 before_script:
   - mkdir build || true
   - cd build
-  - CC=$CCOMPILE CXX=$CXXCOMPILE $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DBUILD_SHARED_LIBS=$SHARED -DTERMINALPP_SANITIZE=$SANITIZE -DTERMINALPP_COVERAGE=$COVERAGE ..
+  - $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DBUILD_SHARED_LIBS=$SHARED -DTERMINALPP_SANITIZE=$SANITIZE -DTERMINALPP_COVERAGE=$COVERAGE ..
 
 script:
   - make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-project(terminalpp)
+if (POLICY CMP0048)
+    cmake_policy(SET CMP0048 NEW)
+    project(TERMINALPP VERSION 1.2.5)
+else()
+    project(TERMINALPP)
+endif()
+
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 cmake_policy(VERSION 3.2)
 
@@ -7,6 +13,7 @@ if (POLICY CMP0063)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules")
+set(CMAKE_DEBUG_POSTFIX d)
 
 # Boost is required as we used Boost.Variant, Boost.Optional, and
 # Boost.Format.  All of these are header-only libraries, so no subcomponents
@@ -21,7 +28,7 @@ include (GenerateExportHeader)
 
 # Due to the strange requirements for Google Test, it is assumed to have been
 # built in the "gtest" directory.  For this, it is required to run the moral
-# equivalent of the following script before building Telnet++:
+# equivalent of the following script before building Terminal++:
 #
 #  mkdir gtest
 #  cd gtest
@@ -162,6 +169,11 @@ generate_export_header(terminalpp
         "${PROJECT_SOURCE_DIR}/include/terminalpp/detail/export.hpp"
 )
 
+configure_file(
+    ${PROJECT_SOURCE_DIR}/include/terminalpp/version.hpp.in
+    ${PROJECT_SOURCE_DIR}/include/terminalpp/version.hpp
+)
+
 install(
     TARGETS
         terminalpp-core
@@ -169,23 +181,46 @@ install(
     EXPORT
         terminalpp-config
     ARCHIVE DESTINATION
-        lib
+        lib/terminalpp-${TERMINALPP_VERSION}
     LIBRARY DESTINATION
-        lib
+        lib/terminalpp-${TERMINALPP_VERSION}
 )
 
 install(
     DIRECTORY
         include/
     DESTINATION
-        include
+        include/terminalpp-${TERMINALPP_VERSION}
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/terminalpp-config-version.cmake"
+    VERSION
+        "${TERMINALPP_VERSION}"
+    COMPATIBILITY AnyNewerVersion
+)
+
+export(
+    EXPORT
+        terminalpp-config
+    FILE
+        "${CMAKE_CURRENT_BINARY_DIR}/terminalpp-config.cmake"
 )
 
 install(
     EXPORT
         terminalpp-config
     DESTINATION
-        share/cmake/terminalpp
+        lib/terminalpp-${TERMINALPP_VERSION}
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/terminalpp-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/terminalpp-config-version.cmake"
+    DESTINATION
+        lib/terminalpp-${TERMINALPP_VERSION}/cmake
 )
 
 if (GTEST_FOUND)
@@ -246,3 +281,14 @@ if (DOXYGEN_FOUND)
             "Generate API documentation with Doxygen" VERBATIM
     )
 endif()
+
+# Add customizations for packaging
+set(CPACK_PACKAGE_NAME "Terminal++")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Terminal++")
+set(CPACK_PACKAGE_VENDOR "Matthew Chaplain")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_VERSION_MAJOR ${TERMINALPP_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${TERMINALPP_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${TERMINALPP_VERSION_PATCH})
+include(CPack)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 KazDragon
+Copyright (c) 2015-2017 Matthew Chaplain a.k.a. KazDragon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/terminalpp/version.hpp.in
+++ b/include/terminalpp/version.hpp.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#define TERMINALPP_VERSION @TERMINALPP_VERSION@
+


### PR DESCRIPTION
Updated license to include real name and current date.
Terminal++ is now properly versioned when installing.  Fixes #164
Added a version header file. Fixes #155
Added a packaging script.  Fixes #157
Update Travis script to build with Trusty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/165)
<!-- Reviewable:end -->
