### PR TITLE
Fix redundant coordinates when moving cursor to home (#174)

### DIFF
--- a/src/detail/terminal_cursor_control.cpp
+++ b/src/detail/terminal_cursor_control.cpp
@@ -125,11 +125,14 @@ std::string cursor_position(
     terminalpp::behaviour const &behaviour,
     control_mode          const &mode)
 {
-    return csi(mode)
-         + std::to_string(pt.y)
-         + terminalpp::ansi::PS
-         + std::to_string(pt.x)
-         + terminalpp::ansi::csi::CURSOR_POSITION;
+    auto result = csi(mode);
+    if (pt.x != 1 || pt.y != 1)
+    {
+        result += std::to_string(pt.y)
+          + terminalpp::ansi::PS
+          + std::to_string(pt.x);
+    }
+    return result + terminalpp::ansi::csi::CURSOR_POSITION;
 }
 
 }}

--- a/test/ansi_terminal_cursor_test.cpp
+++ b/test/ansi_terminal_cursor_test.cpp
@@ -13,6 +13,25 @@ TEST(a_ansi_terminal_with_an_unknown_location, sends_absolute_coordinates_when_m
         terminal.move_cursor({2, 2}));
 }
 
+TEST(a_ansi_terminal_with_an_unknown_location, omits_coordinates_when_moving_to_top_left)
+{
+    terminalpp::ansi_terminal terminal;
+
+    expect_sequence(
+        std::string("\x1B[H"),
+        terminal.move_cursor({0, 0}));
+}
+
+TEST(a_ansi_terminal_with_a_known_location, omits_coordinates_when_moving_to_top_left)
+{
+    terminalpp::ansi_terminal terminal;
+    terminal.move_cursor({10, 10});
+
+    expect_sequence(
+        std::string("\x1B[H"),
+        terminal.move_cursor({0, 0}));
+}
+
 TEST(a_ansi_terminal_with_a_known_location, sends_nothing_when_moving_to_the_same_coordinates)
 {
     terminalpp::ansi_terminal terminal;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/176)
<!-- Reviewable:end -->
