### PR TITLE
Added new constructor for terminalpp::string

### DIFF
--- a/include/terminalpp/string.hpp
+++ b/include/terminalpp/string.hpp
@@ -83,6 +83,13 @@ public :
     string(std::string const &text, terminalpp::attribute const &attr);
 
     //* =====================================================================
+    /// \brief Construct a string of a number of identical elements.
+    /// \param size the size of the string to construct.
+    /// \param elem a prototype element to fill the string with
+    //* =====================================================================
+    string(std::size_t size, terminalpp::element const &elem);
+
+    //* =====================================================================
     /// \brief Returns the number of elements in the string.
     //* =====================================================================
     std::size_t size() const;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -18,7 +18,7 @@ string::string(std::initializer_list<element> const &ilist)
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
-string::string(const char* text)
+string::string(char const* text)
   : string(text, strlen(text))
 {
 }
@@ -26,7 +26,7 @@ string::string(const char* text)
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
-string::string(const char* text, std::size_t len)
+string::string(char const* text, std::size_t len)
   : elements_(text, text + len)
 {
 }
@@ -34,7 +34,7 @@ string::string(const char* text, std::size_t len)
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
-string::string(const std::string& text)
+string::string(std::string const &text)
   : string(text.c_str(), text.size())
 {
 }
@@ -50,6 +50,14 @@ string::string(std::string const &text, terminalpp::attribute const &attr)
     {
         elem.attribute_ = attr;
     });
+}
+
+// ==========================================================================
+// CONSTRUCTOR
+// ==========================================================================
+string::string(std::size_t size, terminalpp::element const &elem)
+  : elements_(size, elem)
+{
 }
 
 // ==========================================================================

--- a/test/string_test.cpp
+++ b/test/string_test.cpp
@@ -70,6 +70,30 @@ TEST(string_test, converting_tstring_with_unicode_values_yields_plain_string_wit
     ASSERT_EQ(expected, str);
 }
 
+TEST(string_test, constructing_a_string_of_no_elements_constructs_an_empty_string)
+{
+    static auto const space = terminalpp::element(' ');
+    ASSERT_EQ(terminalpp::string(0, space), terminalpp::string());
+}
+
+TEST(string_test, constructing_a_string_with_a_size_and_an_element_constructs_a_string_of_that_many_elements)
+{
+    static auto const elem = terminalpp::element('?');
+    static auto const size = std::size_t(36);
+    static auto const expected = [&]()
+    {
+        terminalpp::string result;
+        for (std::size_t index = 0; index < size; ++index)
+        {
+            result += elem;
+        }
+
+        return result;
+    }();
+
+    ASSERT_EQ(terminalpp::string(size, elem), expected);
+}
+
 using string_string = std::tuple<
     terminalpp::string,
     std::string


### PR DESCRIPTION
o Can construct a string of a given length filled with copies of a
  prototype element.

Closes #179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/181)
<!-- Reviewable:end -->
