### PR TITLE
Changed to default constructor in test due to ambiguity revealed by gcc 7

### DIFF
--- a/test/attribute_test.cpp
+++ b/test/attribute_test.cpp
@@ -29,7 +29,7 @@ TEST_P(attributes_with_strings, can_be_streamed_to_an_ostream)
 
 static attribute_string const attribute_strings[] = {
     // All defaults
-    attribute_string { {},  "" },
+    attribute_string {},
 
     // One non-default value
     attribute_string {


### PR DESCRIPTION
Fixes #196

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/197)
<!-- Reviewable:end -->
