### PR TITLE
Replaced uses of Boost.Format with fmtlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,10 @@ set_target_properties(terminalpp
 
 target_link_libraries(terminalpp
     PUBLIC
-        CONAN_PKG::boost_format
         CONAN_PKG::boost_optional
         CONAN_PKG::boost_variant
+    PRIVATE
+        CONAN_PKG::fmt
 )
 
 generate_export_header(terminalpp
@@ -241,6 +242,7 @@ if (TERMINALPP_WITH_TESTS)
     target_link_libraries(terminalpp_tester
         terminalpp
         CONAN_PKG::gtest
+        CONAN_PKG::fmt
     )
 
     add_test(terminalpp_test terminalpp_tester)

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class TerminalppConan(ConanFile):
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     options = {"shared": [True, False], "withTests": [True, False]}
     default_options = {"shared": False, "withTests": False}
-    requires = ("boost_format/[>=1.69]@bincrafters/stable",
+    requires = ("fmt/[>=5.3]@bincrafters/stable",
                 "boost_optional/[>=1.69]@bincrafters/stable",
                 "boost_variant/[>=1.69]@bincrafters/stable")
     generators = "cmake"

--- a/src/detail/element_difference.cpp
+++ b/src/detail/element_difference.cpp
@@ -3,7 +3,7 @@
 #include "terminalpp/behaviour.hpp"
 #include "terminalpp/element.hpp"
 #include "terminalpp/ansi/protocol.hpp"
-#include <boost/format.hpp>
+#include <fmt/format.h>
 
 // TODO: In some cases, switching from one character set to the other
 // wont make any difference, so we can "carry" the charset for as long as
@@ -11,6 +11,8 @@
 // but different in DEC (where it is a shadowed block).  Therefore, when
 // printing a glyph in UK charset then 'a' in US charset, it's not actually
 // necessary to change charset (yet).
+
+using namespace fmt::literals;
 
 namespace terminalpp { namespace detail {
 
@@ -75,7 +77,7 @@ static void append_graphics_change(
         change += terminalpp::ansi::PS;
     }
 
-    change += boost::str(boost::format("%d") % int(dest.value_));
+    change += "{}"_format(int(dest.value_));
 }
 
 // ==========================================================================
@@ -86,7 +88,7 @@ static std::string low_foreground_colour_code(terminalpp::low_colour const &col)
     int value = int(col.value_)
               + terminalpp::ansi::graphics::FOREGROUND_COLOUR_BASE;
 
-    return boost::str(boost::format("%d") % value);
+    return "{}"_format(value);
 }
 
 // ==========================================================================
@@ -94,7 +96,7 @@ static std::string low_foreground_colour_code(terminalpp::low_colour const &col)
 // ==========================================================================
 static std::string high_foreground_colour_code(terminalpp::high_colour const &col)
 {
-    return boost::str(boost::format("38;5;%d") % int(col.value_));
+    return "38;5;{}"_format(int(col.value_));
 }
 
 // ==========================================================================
@@ -103,7 +105,7 @@ static std::string high_foreground_colour_code(terminalpp::high_colour const &co
 static std::string greyscale_foreground_colour_code(
     terminalpp::greyscale_colour const &col)
 {
-    return boost::str(boost::format("38;5;%d") % int(col.shade_));
+    return "38;5;{}"_format(int(col.shade_));
 }
 
 // ==========================================================================
@@ -156,9 +158,9 @@ static void append_foreground_colour(
 static std::string low_background_colour_code(terminalpp::low_colour const &col)
 {
     int value = int(col.value_)
-    + terminalpp::ansi::graphics::BACKGROUND_COLOUR_BASE;
+      + terminalpp::ansi::graphics::BACKGROUND_COLOUR_BASE;
 
-    return boost::str(boost::format("%d") % value);
+    return "{}"_format(value);
 }
 
 // ==========================================================================
@@ -166,7 +168,7 @@ static std::string low_background_colour_code(terminalpp::low_colour const &col)
 // ==========================================================================
 static std::string high_background_colour_code(terminalpp::high_colour const &col)
 {
-    return boost::str(boost::format("48;5;%d") % int(col.value_));
+    return "48;5;{}"_format(int(col.value_));
 }
 
 // ==========================================================================
@@ -175,7 +177,7 @@ static std::string high_background_colour_code(terminalpp::high_colour const &co
 static std::string greyscale_background_colour_code(
     terminalpp::greyscale_colour const &col)
 {
-    return boost::str(boost::format("48;5;%d") % int(col.shade_));
+    return "48;5;{}"_format(int(col.shade_));
 }
 
 // ==========================================================================
@@ -227,11 +229,12 @@ static void append_background_colour(
 // ==========================================================================
 static std::string default_attribute()
 {
-    return boost::str(
-        boost::format("%s%d%c")
-      % terminalpp::ansi::control7::CSI
-      % int(terminalpp::ansi::graphics::NO_ATTRIBUTES)
-      % terminalpp::ansi::csi::SELECT_GRAPHICS_RENDITION);
+    static auto const default_attribute_string = "{}{}{}"_format(
+        terminalpp::ansi::control7::CSI,
+        int(terminalpp::ansi::graphics::NO_ATTRIBUTES),
+        terminalpp::ansi::csi::SELECT_GRAPHICS_RENDITION);
+
+    return default_attribute_string;
 }
 
 // ==========================================================================

--- a/test/expect_sequence.cpp
+++ b/test/expect_sequence.cpp
@@ -1,6 +1,6 @@
 #include "expect_sequence.hpp"
 #include <gtest/gtest.h>
-#include <boost/format.hpp>
+#include <fmt/format.h>
 #include <cctype>
 
 static std::string escape(std::string const &str)
@@ -11,7 +11,8 @@ static std::string escape(std::string const &str)
     {
         if (!isprint(ch))
         {
-            result += boost::str(boost::format("0x%02X") % int(ch));
+            using namespace fmt::literals;
+            result += "0x{:02X}"_format(int(ch));
         }
         else
         {
@@ -24,7 +25,6 @@ static std::string escape(std::string const &str)
 
 void expect_sequence(std::string const &expected, std::string const &result)
 {
-
     if (expected != result)
     {
         std::cout << "\n"


### PR DESCRIPTION
In tests, changing out Boost.Format for usage of fmtlib reduced the impact of element_difference from 26% to 18%, with the string parsing (that isn't inlined) now taking only 14% of the time to change attributes.

Closes #199 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/200)
<!-- Reviewable:end -->
