### PR TITLE
A terminal now explicitly sets the default attribute before writing any text.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ set_target_properties(terminalpp
 target_link_libraries(terminalpp
     PUBLIC
         CONAN_PKG::boost_optional
+        CONAN_PKG::boost_range
         CONAN_PKG::boost_variant
     PRIVATE
         CONAN_PKG::fmt

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class TerminalppConan(ConanFile):
     default_options = {"shared": False, "withTests": False}
     requires = ("fmt/[>=5.3]@bincrafters/stable",
                 "boost_optional/[>=1.69]@bincrafters/stable",
+                "boost_range/[>=1.69]@bincrafters/stable",
                 "boost_variant/[>=1.69]@bincrafters/stable")
     generators = "cmake"
 

--- a/include/terminalpp/ansi_terminal.hpp
+++ b/include/terminalpp/ansi_terminal.hpp
@@ -126,7 +126,7 @@ private :
     boost::optional<point>        cursor_position_;
     boost::optional<point>        saved_cursor_position_;
     boost::optional<extent>       size_;
-    element                       last_element_;
+    boost::optional<element>      last_element_;
 
     detail::parser                parser_;
 };

--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -11,6 +11,12 @@ class element;
 namespace detail {
 
 //* =========================================================================
+/// \brief Returns a string of ANSI codes that sets the attributes to the
+/// default.
+//* =========================================================================
+std::string default_attribute();
+
+//* =========================================================================
 /// \brief Returns a string of ANSI codes that describes the difference
 /// between two elements.
 /// \par

--- a/src/ansi_terminal.cpp
+++ b/src/ansi_terminal.cpp
@@ -5,6 +5,7 @@
 #include "terminalpp/detail/element_difference.hpp"
 #include "terminalpp/detail/parser.hpp"
 #include "terminalpp/detail/well_known_virtual_key.hpp"
+#include <boost/range/numeric.hpp>
 #include <cassert>
 
 namespace terminalpp {
@@ -344,6 +345,12 @@ std::string ansi_terminal::write(element const &elem)
 {
     std::string result;
 
+    if (!last_element_)
+    {
+        result += detail::default_attribute();
+        last_element_ = terminalpp::element{};
+    }
+
     result += detail::element_difference(*last_element_, elem, behaviour_);
     result += write_element(elem);
 
@@ -383,13 +390,15 @@ std::string ansi_terminal::write(string const& str)
         last_element_ = terminalpp::element{};
     }
 
-    std::for_each(str.begin(), str.end(),
-        [&result, this](auto const &elem)
+    return boost::accumulate(
+        str,
+        result,
+        [this](std::string &result, terminalpp::element const &elem) 
+            -> std::string &
         {
             result += this->write(elem);
+            return result;
         });
-
-    return result;
 }
 
 // ==========================================================================

--- a/src/ansi_terminal.cpp
+++ b/src/ansi_terminal.cpp
@@ -342,9 +342,10 @@ std::vector<terminalpp::token> ansi_terminal::read(std::string const &data)
 // ==========================================================================
 std::string ansi_terminal::write(element const &elem)
 {
-    std::string result =
-        detail::element_difference(last_element_, elem, behaviour_)
-      + write_element(elem);
+    std::string result;
+
+    result += detail::element_difference(*last_element_, elem, behaviour_);
+    result += write_element(elem);
 
     if (cursor_position_)
     {
@@ -375,6 +376,12 @@ std::string ansi_terminal::write(element const &elem)
 std::string ansi_terminal::write(string const& str)
 {
     std::string result;
+
+    if (!last_element_)
+    {
+        result += detail::default_attribute();
+        last_element_ = terminalpp::element{};
+    }
 
     std::for_each(str.begin(), str.end(),
         [&result, this](auto const &elem)

--- a/src/detail/element_difference.cpp
+++ b/src/detail/element_difference.cpp
@@ -225,19 +225,6 @@ static void append_background_colour(
 }
 
 // ==========================================================================
-// DEFAULT_ATTRIBUTE
-// ==========================================================================
-static std::string default_attribute()
-{
-    static auto const default_attribute_string = "{}{}{}"_format(
-        terminalpp::ansi::control7::CSI,
-        int(terminalpp::ansi::graphics::NO_ATTRIBUTES),
-        terminalpp::ansi::csi::SELECT_GRAPHICS_RENDITION);
-
-    return default_attribute_string;
-}
-
-// ==========================================================================
 // CHANGE_ATTRIBUTE
 // ==========================================================================
 static std::string change_attribute(
@@ -270,6 +257,19 @@ static std::string change_attribute(
     return result;
 }
 
+}
+
+// ==========================================================================
+// DEFAULT_ATTRIBUTE
+// ==========================================================================
+std::string default_attribute()
+{
+    static auto const default_attribute_string = "{}{}{}"_format(
+        terminalpp::ansi::control7::CSI,
+        int(terminalpp::ansi::graphics::NO_ATTRIBUTES),
+        terminalpp::ansi::csi::SELECT_GRAPHICS_RENDITION);
+
+    return default_attribute_string;
 }
 
 // ==========================================================================

--- a/test/ansi_terminal_string_test.cpp
+++ b/test/ansi_terminal_string_test.cpp
@@ -4,254 +4,237 @@
 
 using namespace terminalpp::literals;
 
-TEST(terminal_string_test, empty_string_outputs_nothing)
+TEST(terminal_string_test, empty_string_outputs_default_attributes)
 {
     terminalpp::ansi_terminal terminal;
+
+    expect_sequence(
+        std::string("\x1B[0m"),
+        terminal.write(""_ets));
+}
+
+TEST(terminal_string_test, outputting_an_empty_string_after_an_empty_string_outputs_nothing)
+{
+    terminalpp::ansi_terminal terminal;
+    terminal.write(""_ets);
 
     expect_sequence(
         std::string(""),
         terminal.write(""_ets));
 }
 
-TEST(terminal_string_test, basic_string_outputs_basic_string)
+TEST(terminal_string_test, basic_string_outputs_default_attributes_and_basic_string)
 {
     terminalpp::ansi_terminal terminal;
+
+    expect_sequence(
+        std::string("\x1B[0mabcde"),
+        terminal.write("abcde"_ets));
+}
+
+TEST(terminal_string_test, outputting_another_basic_string_does_not_output_default_attributes)
+{
+    terminalpp::ansi_terminal terminal;
+    terminal.write("abcde"_ets);
 
     expect_sequence(
         std::string("abcde"),
         terminal.write("abcde"_ets));
 }
 
-TEST(terminal_string_test, changed_charset_outputs_charset_code)
+class an_ansi_terminal : public testing::Test
 {
-    terminalpp::ansi_terminal terminal;
+protected:
+    an_ansi_terminal()
+    {
+        // Here we stimulate the terminal to output its initial attribute-clear
+        // so that it isn't involved in every other test.
+        terminal_.write(""_ets);
+    }
 
+    terminalpp::ansi_terminal terminal_;
+};
+
+TEST_F(an_ansi_terminal, changed_charset_outputs_charset_code)
+{
     expect_sequence(
         std::string("\x1B(0abcde"),
-        terminal.write("\\c0abcde"_ets));
+        terminal_.write("\\c0abcde"_ets));
 }
 
-TEST(terminal_string_test, changed_charset_then_second_charset_outputs_charset_codes)
+TEST_F(an_ansi_terminal, changed_charset_then_second_charset_outputs_charset_codes)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B(0abc\x1B(Ade"),
-        terminal.write("\\c0abc\\cAde"_ets));
+        terminal_.write("\\c0abc\\cAde"_ets));
 }
 
-TEST(terminal_string_test, bold_intensity_outputs_intensity)
+TEST_F(an_ansi_terminal, bold_intensity_outputs_intensity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[1mabcde"),
-        terminal.write("\\i>abcde"_ets));
+        terminal_.write("\\i>abcde"_ets));
 }
 
-TEST(terminal_string_test, faint_intensity_outputs_intensity)
+TEST_F(an_ansi_terminal, faint_intensity_outputs_intensity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[2mabcde"),
-        terminal.write("\\i<abcde"_ets));
+        terminal_.write("\\i<abcde"_ets));
 }
 
-TEST(terminal_string_test, normal_intensity_does_not_output_intensity)
+TEST_F(an_ansi_terminal, normal_intensity_does_not_output_intensity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("abcde"),
-        terminal.write("\\i=abcde"_ets));
+        terminal_.write("\\i=abcde"_ets));
 }
 
-TEST(terminal_string_test, bold_then_normal_intensity_outputs_intensity)
+TEST_F(an_ansi_terminal, bold_then_normal_intensity_outputs_intensity)
 {
     // Note: an alternative possible normal string would be
     // \x1B[22m, but since this is longer, \x1B[0m (all attributes to default)
     // should be chosen.
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[1mabc\x1B[0mde"),
-        terminal.write("\\i>abc\\i=de"_ets));
+        terminal_.write("\\i>abc\\i=de"_ets));
 }
 
-TEST(terminal_string_test, default_intensity_is_normal_intensity)
+TEST_F(an_ansi_terminal, default_intensity_is_normal_intensity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[1mabc\x1B[0mde"),
-        terminal.write("\\i>abc\\ixde"_ets));
+        terminal_.write("\\i>abc\\ixde"_ets));
 }
 
-TEST(terminal_string_test, positive_polarity_does_not_output_polarity)
+TEST_F(an_ansi_terminal, positive_polarity_does_not_output_polarity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("abcde"),
-        terminal.write("\\p+abcde"_ets));
+        terminal_.write("\\p+abcde"_ets));
 }
 
-TEST(terminal_string_test, negative_polarity_outputs_polarity)
+TEST_F(an_ansi_terminal, negative_polarity_outputs_polarity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[7mabcde"),
-        terminal.write("\\p-abcde"_ets));
+        terminal_.write("\\p-abcde"_ets));
 }
 
-TEST(terminal_string_test, negative_then_positive_polarity_outputs_polarity)
+TEST_F(an_ansi_terminal, negative_then_positive_polarity_outputs_polarity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[7mabc\x1B[0mde"),
-        terminal.write("\\p-abc\\p+de"_ets));
+        terminal_.write("\\p-abc\\p+de"_ets));
 }
 
-TEST(terminal_string_test, default_polarity_is_positive_polarity)
+TEST_F(an_ansi_terminal, default_polarity_is_positive_polarity)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[7mabc\x1B[0mde"),
-        terminal.write("\\p-abc\\p=de"_ets));
+        terminal_.write("\\p-abc\\p=de"_ets));
 }
 
-TEST(terminal_string_test, positive_underlining_outputs_underlining)
+TEST_F(an_ansi_terminal, positive_underlining_outputs_underlining)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[4mabcde"),
-        terminal.write("\\u+abcde"_ets));
+        terminal_.write("\\u+abcde"_ets));
 }
 
-TEST(terminal_string_test, negative_underlining_does_not_output_underlining)
+TEST_F(an_ansi_terminal, negative_underlining_does_not_output_underlining)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("abcde"),
-        terminal.write("\\u-abcde"_ets));
+        terminal_.write("\\u-abcde"_ets));
 }
 
-TEST(terminal_string_test, positive_then_negative_underlining_outputs_underlining)
+TEST_F(an_ansi_terminal, positive_then_negative_underlining_outputs_underlining)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[4mabc\x1B[0mde"),
-        terminal.write("\\u+abc\\u-de"_ets));
+        terminal_.write("\\u+abc\\u-de"_ets));
 }
 
-TEST(terminal_string_test, default_underlining_is_negative_underlining)
+TEST_F(an_ansi_terminal, default_underlining_is_negative_underlining)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[4mabc\x1B[0mde"),
-        terminal.write("\\u+abc\\u=de"_ets));
+        terminal_.write("\\u+abc\\u=de"_ets));
 }
 
-TEST(terminal_string_test, foreground_low_colour_outputs_foreground_colour)
+TEST_F(an_ansi_terminal, foreground_low_colour_outputs_foreground_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[32mabc"),
-        terminal.write("\\[2abc"_ets));
+        terminal_.write("\\[2abc"_ets));
 }
 
-TEST(terminal_string_test, foreground_high_colour_outputs_foreground_colour)
+TEST_F(an_ansi_terminal, foreground_high_colour_outputs_foreground_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[38;5;202mabc"),
-        terminal.write("\\<510abc"_ets));
+        terminal_.write("\\<510abc"_ets));
 }
 
-TEST(terminal_string_test, foreground_greyscale_colour_outputs_foreground_colour)
+TEST_F(an_ansi_terminal, foreground_greyscale_colour_outputs_foreground_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[38;5;244mabc"),
-        terminal.write("\\{12abc"_ets));
+        terminal_.write("\\{12abc"_ets));
 }
 
-TEST(terminal_string_test, default_foreground_colour_does_not_output_foreground_colour)
+TEST_F(an_ansi_terminal, default_foreground_colour_does_not_output_foreground_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("abc"),
-        terminal.write("\\[9abc"_ets));
+        terminal_.write("\\[9abc"_ets));
 }
 
-TEST(terminal_string_test, multiple_foreground_colour_codes_outputs_foreground_colours)
+TEST_F(an_ansi_terminal, multiple_foreground_colour_codes_outputs_foreground_colours)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[32mab\x1B[38;5;202mcd\x1B[38;5;234mef\x1B[0mgh"),
-        terminal.write("\\[2ab\\<510cd\\{02ef\\[9gh"_ets));
+        terminal_.write("\\[2ab\\<510cd\\{02ef\\[9gh"_ets));
 }
 
 
-TEST(terminal_string_test, background_low_colour_outputs_background_colour)
+TEST_F(an_ansi_terminal, background_low_colour_outputs_background_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[42mabc"),
-        terminal.write("\\]2abc"_ets));
+        terminal_.write("\\]2abc"_ets));
 }
 
-TEST(terminal_string_test, background_high_colour_outputs_background_colour)
+TEST_F(an_ansi_terminal, background_high_colour_outputs_background_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[48;5;202mabc"),
-        terminal.write("\\>510abc"_ets));
+        terminal_.write("\\>510abc"_ets));
 }
 
-TEST(terminal_string_test, background_greyscale_colour_outputs_background_colour)
+TEST_F(an_ansi_terminal, background_greyscale_colour_outputs_background_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[48;5;244mabc"),
-        terminal.write("\\}12abc"_ets));
+        terminal_.write("\\}12abc"_ets));
 }
 
-TEST(terminal_string_test, default_background_colour_does_not_output_background_colour)
+TEST_F(an_ansi_terminal, default_background_colour_does_not_output_background_colour)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("abc"),
-        terminal.write("\\]9abc"_ets));
+        terminal_.write("\\]9abc"_ets));
 }
 
-TEST(terminal_string_test, multiple_background_colour_codes_outputs_background_colours)
+TEST_F(an_ansi_terminal, multiple_background_colour_codes_outputs_background_colours)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[42mab\x1B[48;5;75mcd\x1B[48;5;234mef\x1B[0mgh"),
-        terminal.write("\\]2ab\\>135cd\\}02ef\\]9gh"_ets));
+        terminal_.write("\\]2ab\\>135cd\\}02ef\\]9gh"_ets));
 }
 
-TEST(terminal_string_test, multiple_attributes_do_not_output_default_change)
+TEST_F(an_ansi_terminal, multiple_attributes_do_not_output_default_change)
 {
     // Test that, when switching off and on multiple attributes, they do not in
     // general go back to default.  Instead, they should toggle specific flags.
@@ -260,140 +243,124 @@ TEST(terminal_string_test, multiple_attributes_do_not_output_default_change)
     // In that case, it may be that switching several attributes off is longer
     // than switching to default then re-enabling one attribute.  It also may
     // be determined by environment - different terminals behave differently.
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B[32;41ma\x1B[7mb\x1B[27mc"),
-        terminal.write("\\[2\\]1a\\p-b\\p+c"_ets));
+        terminal_.write("\\[2\\]1a\\p-b\\p+c"_ets));
 }
 
-TEST(terminal_string_test, writing_string_moves_cursor)
+TEST_F(an_ansi_terminal, writing_string_moves_cursor)
 {
-    terminalpp::ansi_terminal terminal;
-
-    terminal.move_cursor({5, 5});
-    terminal.write("abcde");
+    terminal_.move_cursor({5, 5});
+    terminal_.write("abcde");
 
     expect_sequence(
         std::string(""),
-        terminal.move_cursor({10, 5}));
+        terminal_.move_cursor({10, 5}));
 }
 
-TEST(terminal_string_test, encoded_glyphs_output_unicode_text)
+TEST_F(an_ansi_terminal, encoded_glyphs_output_unicode_text)
 {
     // If a string contains a four-hexdigit unicode code, then
     // it should be output as a unicode character if it can be.
     // This will include commands to change to and from the utf-8
     // character set and also to reset the character set at the end.
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B%GW"),
-        terminal.write("\\U0057"_ets));
+        terminal_.write("\\U0057"_ets));
 
     expect_sequence(
         std::string("\xC4\x8E"),
-        terminal.write("\\U010E"_ets));
+        terminal_.write("\\U010E"_ets));
 
     expect_sequence(
         std::string("\xE1\x9A\xB8"),
-        terminal.write("\\U16B8"_ets));
+        terminal_.write("\\U16B8"_ets));
 }
 
-TEST(terminal_string_test, writing_past_terminal_width_moves_cursor_to_next_line)
+TEST_F(an_ansi_terminal, writing_past_terminal_width_moves_cursor_to_next_line)
 {
-    terminalpp::ansi_terminal terminal;
-    terminal.set_size({10, 10});
-    terminal.move_cursor({8, 8});
-    terminal.write("abcde");
+    terminal_.set_size({10, 10});
+    terminal_.move_cursor({8, 8});
+    terminal_.write("abcde");
 
     expect_sequence(
         std::string(""),
-        terminal.move_cursor({3, 9}));
+        terminal_.move_cursor({3, 9}));
 }
 
-TEST(terminal_string_test, writing_far_past_terminal_width_moves_multiple_lines)
+TEST_F(an_ansi_terminal, writing_far_past_terminal_width_moves_multiple_lines)
 {
-    terminalpp::ansi_terminal terminal;
-    terminal.set_size({10, 10});
-    terminal.move_cursor({8, 8});
-    terminal.write("abcdefghijklmno");
+    terminal_.set_size({10, 10});
+    terminal_.move_cursor({8, 8});
+    terminal_.write("abcdefghijklmno");
 
     expect_sequence(
         std::string(""),
-        terminal.move_cursor({3, 10}));
+        terminal_.move_cursor({3, 10}));
 }
 
-TEST(terminal_string_test, writing_past_last_line_scrolls_last_line)
+TEST_F(an_ansi_terminal, writing_past_last_line_scrolls_last_line)
 {
-    terminalpp::ansi_terminal terminal;
-    terminal.set_size({10, 10});
-    terminal.move_cursor({8, 10});
-    terminal.write("abcdefghijklmno");
+    terminal_.set_size({10, 10});
+    terminal_.move_cursor({8, 10});
+    terminal_.write("abcdefghijklmno");
 
     expect_sequence(
         std::string(""),
-        terminal.move_cursor({3, 10}));
+        terminal_.move_cursor({3, 10}));
 }
 
-TEST(terminal_string_test, can_write_single_element)
+TEST_F(an_ansi_terminal, can_write_single_element)
 {
-    terminalpp::ansi_terminal terminal;
     terminalpp::element  elem('X');
     elem.attribute_.foreground_colour_ =
         terminalpp::ansi::graphics::colour::red;
 
     expect_sequence(
         std::string("\x1B[31mX"),
-        terminal.write(elem));
+        terminal_.write(elem));
 }
 
-TEST(terminal_string_test, writing_single_element_moves_cursor)
+TEST_F(an_ansi_terminal, writing_single_element_moves_cursor)
 {
-    terminalpp::ansi_terminal terminal;
-    terminal.set_size({5, 5});
-    terminal.move_cursor({0, 0});
-    terminal.write('x');
+    terminal_.set_size({5, 5});
+    terminal_.move_cursor({0, 0});
+    terminal_.write('x');
 
     expect_sequence(
         std::string(""),
-        terminal.move_cursor({1, 0}));
+        terminal_.move_cursor({1, 0}));
 }
 
-TEST(terminal_string_test, writing_unicode_after_default_charset_does_not_change_charset_first)
+TEST_F(an_ansi_terminal, writing_unicode_after_default_charset_does_not_change_charset_first)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string(" \x1B%GW"),
-        terminal.write(" \\U0057"_ets));
+        terminal_.write(" \\U0057"_ets));
 }
 
-TEST(terminal_string_test, writing_unicode_after_sco_charset_reverts_charset_first)
+TEST_F(an_ansi_terminal, writing_unicode_after_sco_charset_reverts_charset_first)
 {
-    terminalpp::ansi_terminal terminal;
-
     expect_sequence(
         std::string("\x1B(U\xCD\x1B(B\x1B%GW"),
-        terminal.write("\\cU\\C205\\U0057"_ets));
+        terminal_.write("\\cU\\C205\\U0057"_ets));
 }
 
 TEST(terminal_string_test, behaviour_unicode_in_all_charsets_writing_unicode_after_sco_does_not_change_charset_first)
 {
     terminalpp::behaviour behaviour;
     behaviour.unicode_in_all_charsets = true;
+    terminalpp::ansi_terminal terminal{behaviour};
 
-    terminalpp::ansi_terminal terminal(behaviour);
     expect_sequence(
-        std::string("\x1B(U\xCD\x1B%GW"),
+        std::string("\x1B[0m\x1B(U\xCD\x1B%GW"),
         terminal.write("\\cU\\C205\\U0057"_ets));
 
 }
 
-TEST(terminal_string_test, changing_character_set_after_unicode_first_selects_default_charset)
+TEST_F(an_ansi_terminal, changing_character_set_after_unicode_first_selects_default_charset)
 {
-    terminalpp::ansi_terminal terminal;
     expect_sequence(
         std::string("\x1B%GW\x1B%@\x1B(A\x9C"),
-        terminal.write("\\U0057\\cA\\C156"_ets));
+        terminal_.write("\\U0057\\cA\\C156"_ets));
 }

--- a/test/manip_test.cpp
+++ b/test/manip_test.cpp
@@ -7,6 +7,7 @@ using namespace terminalpp::literals;
 TEST(a_terminal, can_have_a_terminal_string_streamed_to_it)
 {
     terminalpp::ansi_terminal terminal;
+    terminal.write(""_ets);
 
     std::string const expected_result = "test";
     std::string const result = terminal << "test"_ts;
@@ -17,6 +18,8 @@ TEST(a_terminal, can_have_a_terminal_string_streamed_to_it)
 TEST(a_terminal, can_have_an_attributed_terminal_string_streamed_to_it)
 {
     terminalpp::ansi_terminal terminal;
+    terminal.write(""_ets);
+
     std::string const expected_result = "\x1B[31mtest";
     std::string const result = terminal << "\\[1test"_ets;
 

--- a/test/screen_test.cpp
+++ b/test/screen_test.cpp
@@ -112,6 +112,7 @@ TEST(screen_test, drawing_after_modifying_one_element_writes_one_element)
     auto canvas = terminalpp::canvas(size);
     auto terminal = terminalpp::ansi_terminal();
     auto reference_terminal = terminalpp::ansi_terminal();
+    reference_terminal.write(""_ts);
 
     terminal.set_size(size);
     reference_terminal.set_size(size);
@@ -131,8 +132,8 @@ TEST(screen_test, drawing_after_modifying_one_element_writes_one_element)
 
     canvas[2][3] = 'x';
 
-    auto expected = reference_terminal.move_cursor({2, 3})
-                  + reference_terminal.write("x"_ts);
+    auto expected = reference_terminal.move_cursor({2, 3});
+    expected += reference_terminal.write("x"_ts);
 
     auto result = screen.draw(terminal, canvas);
 
@@ -145,6 +146,7 @@ TEST(screen_test, drawing_after_modifying_two_elements_writes_two_elements)
     auto canvas = terminalpp::canvas(size);
     auto terminal = terminalpp::ansi_terminal();
     auto reference_terminal = terminalpp::ansi_terminal();
+    reference_terminal.write(""_ts);
 
     terminal.set_size(size);
     reference_terminal.set_size(size);
@@ -181,6 +183,7 @@ TEST(screen_test, drawing_consecutive_elements_does_not_write_cursor_moves)
     auto canvas = terminalpp::canvas(size);
     auto terminal = terminalpp::ansi_terminal();
     auto reference_terminal = terminalpp::ansi_terminal();
+    reference_terminal.write(""_ts);
 
     terminal.set_size(size);
     reference_terminal.set_size(size);


### PR DESCRIPTION
This ensures that drawing on a terminal that has, for example, an attribute
set from a previous application will no longer bleed that attribute until
the first non-default attribute is seen.

Fixed #185

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/203)
<!-- Reviewable:end -->
