### PR TITLE
Fix Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ matrix:
 cache:
   - apt: true
   - directories:
-    - lcov
-    - .conan
+    - $HOME/lcov
+    - $HOME/.conan
 
 before_install:
 # Set up CC/CXX variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,8 @@ before_install:
 before_script:
   - mkdir build || true
   - cd build
-  - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite
-  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+  - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite || true
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
   - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o terminalpp:withTests=True --build=missing
   - $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DBUILD_SHARED_LIBS=$SHARED -DTERMINALPP_WITH_TESTS=True -DTERMINALPP_SANITIZE=$SANITIZE -DTERMINALPP_COVERAGE=$COVERAGE ..
 


### PR DESCRIPTION
Reduces build time on Travis by about a third due to not having to download all Conan packages each time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/213)
<!-- Reviewable:end -->
