### PR TITLE
Removed withTests option from Conan.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,11 +102,10 @@ before_script:
   - cd build
   - conan remote add nonstd-lite https://api.bintray.com/conan/agauniyal/nonstd-lite || true
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
-  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -o terminalpp:withTests=True --build=missing
-  - $CMAKE -DCMAKE_BUILD_TYPE=$CONFIG -DBUILD_SHARED_LIBS=$SHARED -DTERMINALPP_WITH_TESTS=True -DTERMINALPP_SANITIZE=$SANITIZE -DTERMINALPP_COVERAGE=$COVERAGE ..
+  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 --build=missing
 
 script:
-  - make -j2
+  - conan build ..
   - if [ "$COVERAGE" == "ON" ]; then
         $LCOV --gcov-tool=gcov-5 --base-directory . --directory . --zerocounters -q;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,66 +206,64 @@ install(
         lib/terminalpp-${TERMINALPP_VERSION}
 )
 
-if (TERMINALPP_WITH_TESTS)
-    enable_testing()
+enable_testing()
 
-    add_executable(terminalpp_tester
-        test/ansi_terminal_init_test.cpp
-        test/ansi_terminal_cursor_test.cpp
-        test/ansi_terminal_read_cursor_test.cpp
-        test/ansi_terminal_read_fkey_test.cpp
-        test/ansi_terminal_read_test.cpp
-        test/ansi_terminal_settings_test.cpp
-        test/ansi_terminal_string_test.cpp
-        test/attribute_test.cpp
-        test/canvas_test.cpp
-        test/character_set_test.cpp
-        test/colour_test.cpp
-        test/control_sequence_test.cpp
-        test/effect_test.cpp
-        test/element_test.cpp
-        test/encoder_test.cpp
-        test/expect_sequence.cpp
-        test/expect_tokens.cpp
-        test/extent_test.cpp
-        test/glyph_test.cpp
-        test/manip_test.cpp
-        test/mouse_test.cpp
-        test/point_test.cpp
-        test/screen_test.cpp
-        test/string_test.cpp
-        test/string_manip_test.cpp
-        test/virtual_key_test.cpp
-    )
+add_executable(terminalpp_tester
+    test/ansi_terminal_init_test.cpp
+    test/ansi_terminal_cursor_test.cpp
+    test/ansi_terminal_read_cursor_test.cpp
+    test/ansi_terminal_read_fkey_test.cpp
+    test/ansi_terminal_read_test.cpp
+    test/ansi_terminal_settings_test.cpp
+    test/ansi_terminal_string_test.cpp
+    test/attribute_test.cpp
+    test/canvas_test.cpp
+    test/character_set_test.cpp
+    test/colour_test.cpp
+    test/control_sequence_test.cpp
+    test/effect_test.cpp
+    test/element_test.cpp
+    test/encoder_test.cpp
+    test/expect_sequence.cpp
+    test/expect_tokens.cpp
+    test/extent_test.cpp
+    test/glyph_test.cpp
+    test/manip_test.cpp
+    test/mouse_test.cpp
+    test/point_test.cpp
+    test/screen_test.cpp
+    test/string_test.cpp
+    test/string_manip_test.cpp
+    test/virtual_key_test.cpp
+)
 
-    target_compile_features(terminalpp_tester
-        PUBLIC
-            cxx_strong_enums
-            cxx_relaxed_constexpr)
+target_compile_features(terminalpp_tester
+    PUBLIC
+        cxx_strong_enums
+        cxx_relaxed_constexpr)
 
-    target_link_libraries(terminalpp_tester
-        terminalpp
-        CONAN_PKG::gtest
-        CONAN_PKG::fmt
-    )
+target_link_libraries(terminalpp_tester
+    terminalpp
+    CONAN_PKG::gtest
+    CONAN_PKG::fmt
+)
 
-    add_test(terminalpp_test terminalpp_tester)
-endif()
+add_test(terminalpp_test terminalpp_tester)
 
 # Add a rule for generating documentation
 if (DOXYGEN_FOUND)
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-        ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-        @ONLY)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    @ONLY)
 
-    add_custom_target(terminalpp_doc
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-        WORKING_DIRECTORY
-            ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT
-            "Generate API documentation with Doxygen" VERBATIM
-    )
+add_custom_target(terminalpp_doc
+    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT
+        "Generate API documentation with Doxygen" VERBATIM
+)
 endif()
 
 # Add customizations for packaging

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,22 +11,18 @@ class TerminalppConan(ConanFile):
     topics = ("terminal-emulators", "ansi-escape-codes")
     settings = "os", "compiler", "build_type", "arch"
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
-    options = {"shared": [True, False], "withTests": [True, False]}
-    default_options = {"shared": False, "withTests": False}
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
     requires = ("fmt/[>=5.3]@bincrafters/stable",
                 "boost_optional/[>=1.69]@bincrafters/stable",
                 "boost_range/[>=1.69]@bincrafters/stable",
                 "boost_variant/[>=1.69]@bincrafters/stable")
+    build_requires = ("gtest/[>=1.8.1]@bincrafters/stable")
     generators = "cmake"
-
-    def requirements(self):
-        if (self.options.withTests):
-            self.requires("gtest/[>=1.8.1]@bincrafters/stable")
 
     def build(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
-        cmake.definitions["TERMINALPP_WITH_TESTS"] = self.options.withTests        
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
They are now implemented as build requirements.  This means that the tests are
always built (and can be executed), but the requirement isn't passed down the
line to a consumer of the binaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/219)
<!-- Reviewable:end -->
