### PR TITLE
Replaced deprecated INSTANTIATE_TEST_CASE_P macro with INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/test/attribute_test.cpp
+++ b/test/attribute_test.cpp
@@ -108,7 +108,7 @@ static attribute_string const attribute_strings[] = {
     },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     attributes_can_be_streamed_to_an_ostream,
     attributes_with_strings,
     ValuesIn(attribute_strings)

--- a/test/character_set_test.cpp
+++ b/test/character_set_test.cpp
@@ -50,7 +50,7 @@ static character_set_string const character_set_strings[] = {
   character_set_string{ terminalpp::ansi::charset::utf8,                       "u"      },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     character_sets_can_be_streamed_to_an_ostream,
     character_sets_with_strings,
     ValuesIn(character_set_strings)

--- a/test/colour_test.cpp
+++ b/test/colour_test.cpp
@@ -55,7 +55,7 @@ static low_colour_string const low_colour_strings[] = {
   low_colour_string{ terminalpp::ansi::graphics::colour::default_, "default" }
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     low_colours_can_be_streamed_to_an_ostream,
     low_colours_with_strings,
     ValuesIn(low_colour_strings)
@@ -96,7 +96,7 @@ static high_colour_string const high_colour_strings[] = {
     high_colour_string{ 5, 3, 1, "#531" }
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     high_colours_can_be_streamed_to_an_ostream,
     high_colours_with_strings,
     ValuesIn(high_colour_strings)
@@ -133,7 +133,7 @@ static greyscale_string const greyscale_strings[] = {
     greyscale_string{ 22, "#22" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     greyscale_colours_can_be_streamed_to_an_ostream,
     greyscale_colours_with_strings,
     ValuesIn(greyscale_strings)

--- a/test/control_sequence_test.cpp
+++ b/test/control_sequence_test.cpp
@@ -162,7 +162,7 @@ static control_sequence_test_data const control_sequence_strings[] =
 
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     control_sequences_can_be_streamed_to_an_ostream,
     control_sequences_with_strings,
     ValuesIn(control_sequence_strings)

--- a/test/effect_test.cpp
+++ b/test/effect_test.cpp
@@ -34,7 +34,7 @@ static intensity_string const intensity_strings[] = {
     intensity_string{ terminalpp::ansi::graphics::intensity::faint,    "faint"  }
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     intensities_can_be_streamed_to_an_ostream,
     intensities_with_strings,
     ValuesIn(intensity_strings)
@@ -68,7 +68,7 @@ static underline_string const underline_strings[] = {
     underline_string{ terminalpp::ansi::graphics::underlining::not_underlined, "not underlined" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     underlines_can_be_streamed_to_an_ostream,
     underlines_with_strings,
     ValuesIn(underline_strings)
@@ -102,7 +102,7 @@ static polarity_string const polarity_strings[] = {
     polarity_string{ terminalpp::ansi::graphics::polarity::negative, "negative" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     polarities_can_be_streamed_to_an_ostream,
     polarities_with_strings,
     ValuesIn(polarity_strings)
@@ -136,7 +136,7 @@ static blink_string const blink_strings[] = {
     blink_string{ terminalpp::ansi::graphics::blinking::steady, "steady"   },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     blinking_can_be_streamed_to_an_ostream,
     blinking_with_strings,
     ValuesIn(blink_strings)

--- a/test/element_test.cpp
+++ b/test/element_test.cpp
@@ -83,7 +83,7 @@ static element_string const element_strings[] = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     elements_can_be_streamed_to_an_ostream,
     elements_with_strings,
     ValuesIn(element_strings)

--- a/test/extent_test.cpp
+++ b/test/extent_test.cpp
@@ -25,7 +25,7 @@ TEST_P(extents_with_strings, can_be_streamed_to_an_ostream)
     ASSERT_EQ(expected, stream.str());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     extents_can_be_streamed_to_an_ostream,
     extents_with_strings,
     ValuesIn(std::vector<extent_string>{

--- a/test/glyph_test.cpp
+++ b/test/glyph_test.cpp
@@ -71,7 +71,7 @@ static glyph_string const glyph_strings[] = {
 
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     glyphs_can_be_streamed_to_an_ostream,
     glyphs_with_strings,
     ValuesIn(glyph_strings)

--- a/test/mouse_test.cpp
+++ b/test/mouse_test.cpp
@@ -97,7 +97,7 @@ static mouse_report_test_data const mouse_report_strings[] = {
     },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     mouse_reports_can_be_streamed_to_an_ostream,
     mouse_reports_with_strings,
     ValuesIn(mouse_report_strings)

--- a/test/palette_test.cpp
+++ b/test/palette_test.cpp
@@ -104,7 +104,7 @@ TEST_P(colour_attribute_strings, output_the_correct_ansi_data)
     ASSERT_EQ(expected, terminal.write(elem));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     palette_colours_stream_to_terminals,
     colour_attribute_strings,
     ValuesIn(colour_attributes)

--- a/test/point_test.cpp
+++ b/test/point_test.cpp
@@ -25,7 +25,7 @@ TEST_P(points_with_strings, can_be_streamed_to_an_ostream)
     ASSERT_EQ(expected, stream.str());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     points_can_be_streamed_to_an_ostream,
     points_with_strings,
     ValuesIn(std::vector<point_string>{
@@ -68,7 +68,7 @@ TEST_P(points_compare, according_to_relops)
     ASSERT_EQ(greater, lhs > rhs);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     using_relational_operators,
     points_compare,
     ValuesIn(std::vector<point_relops_data>{

--- a/test/rectangle_test.cpp
+++ b/test/rectangle_test.cpp
@@ -27,7 +27,7 @@ TEST_P(rectangles_with_strings, can_be_streamed_to_an_ostream)
     ASSERT_EQ(expected, stream.str());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     rectangles_can_be_streamed_to_an_ostream,
     rectangles_with_strings,
     ValuesIn(std::vector<rectangle_string>{

--- a/test/string_test.cpp
+++ b/test/string_test.cpp
@@ -128,7 +128,7 @@ static string_string const string_strings[] = {
                                      "element[glyph[g],attribute[foreground[red],background[green]]]" }
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     strings_can_be_streamed_to_an_ostream,
     strings_with_strings,
     ValuesIn(string_strings)
@@ -167,7 +167,7 @@ TEST_P(strings_compare, according_to_relops)
     ASSERT_EQ(greater, lhs > rhs);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     using_relational_operators,
     strings_compare,
     ValuesIn(std::vector<string_relops_data>{

--- a/test/virtual_key_test.cpp
+++ b/test/virtual_key_test.cpp
@@ -388,7 +388,7 @@ static virtual_key_test_data const virtual_key_strings[] = {
 
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     virtual_keys_can_be_streamed_to_an_ostream,
     virtual_keys_with_strings,
     ValuesIn(virtual_key_strings)


### PR DESCRIPTION
This is due to the former being deprecated in favour of the latter
by Google Test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/234)
<!-- Reviewable:end -->
