### PR TITLE
Missing headers and fix for end iterator dereferencing

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -20,7 +20,7 @@ auto begin_pointer(Container &&container)
 template <class Container>
 auto end_pointer(Container &&container)
 {
-    return container.empty() ? nullptr : &*container.end();
+    return container.empty() ? nullptr : &*container.begin() + container.size();
 }
 
 }

--- a/src/extent.cpp
+++ b/src/extent.cpp
@@ -1,5 +1,6 @@
 #include "terminalpp/extent.hpp"
 #include <ostream>
+#include <string>
 
 namespace terminalpp {
 

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -1,5 +1,6 @@
 #include "terminalpp/point.hpp"
 #include <ostream>
+#include <string>
 
 namespace terminalpp {
 

--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -1,4 +1,5 @@
 #include "terminalpp/rectangle.hpp"
+#include <ostream>
 
 namespace terminalpp {
 


### PR DESCRIPTION
- Added some missing headers, which are necessary to compile with VS2019

- Dereferencing the end() iterator of a container makes VS trigger an assertion. The proposed solution dereferences the begin() iterator (it the container is not empty) and uses pointer arithmetic to make the  end pointer.

- Maybe the name of the template parameter "container" is a bit misleading as this technique works only with vector and string, but not for lists, so "ContinousContainer" could be a better name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/239)
<!-- Reviewable:end -->
