### PR TITLE
Improve coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,9 @@ add_executable(terminalpp_tester)
 
 target_sources(terminalpp_tester
     PRIVATE
+        test/expect_tokens.hpp
+        test/terminal_test.hpp
+
         test/attribute_test.cpp
         test/canvas_test.cpp
         test/character_set_test.cpp
@@ -288,6 +291,7 @@ target_sources(terminalpp_tester
         test/string_manip_test.cpp
         test/terminal_init_test.cpp
         test/terminal_cursor_test.cpp
+        test/terminal_erase_test.cpp
         test/terminal_read_cursor_test.cpp
         test/terminal_read_fkey_test.cpp
         test/terminal_read_test.cpp

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -457,7 +457,8 @@ std::string terminal::erase_in_display(terminal::erase_display how)
             break;
 
         case terminal::erase_display::below :
-            result += terminalpp::ansi::csi::ERASE_IN_DISPLAY_BELOW;
+            // Erase below uses code 0, which can be omitted.
+            // result += terminalpp::ansi::csi::ERASE_IN_DISPLAY_BELOW;
             break;
     }
 
@@ -488,7 +489,8 @@ std::string terminal::erase_in_line(terminal::erase_line how)
             break;
 
         case terminal::erase_line::right :
-            result += terminalpp::ansi::csi::ERASE_IN_LINE_RIGHT;
+            // Erase to the right uses code 0, which can be omitted.
+            // result += terminalpp::ansi::csi::ERASE_IN_LINE_RIGHT;
             break;
     }
 

--- a/test/manip_test.cpp
+++ b/test/manip_test.cpp
@@ -10,7 +10,8 @@ TEST(a_new_terminal, can_have_a_new_terminal_string_streamed_to_it)
     terminal.write(""_ets);
 
     std::string const expected_result = "test";
-    std::string const result = terminal << "test"_ts;
+    auto const data = "test"_ts;
+    std::string const result = terminal << data;
 
     ASSERT_EQ(expected_result, result);
 }

--- a/test/terminal_erase_test.cpp
+++ b/test/terminal_erase_test.cpp
@@ -1,0 +1,75 @@
+#include "terminal_test.hpp"
+#include "expect_sequence.hpp"
+#include <gtest/gtest.h>
+
+TEST_F(a_terminal, can_erase_its_entire_display)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[2J"),
+
+        // action
+        terminal.erase_in_display(terminalpp::terminal::erase_display::all));
+}
+
+TEST_F(a_terminal, can_erase_its_entire_display_above_the_cursor)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[1J"),
+
+        // action
+        terminal.erase_in_display(terminalpp::terminal::erase_display::above));
+}
+
+TEST_F(a_terminal, can_erase_its_entire_display_below_the_cursor)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[J"),
+
+        // action
+        terminal.erase_in_display(terminalpp::terminal::erase_display::below));
+}
+
+TEST_F(a_terminal, can_erase_an_entire_line)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[2K"),
+
+        // action
+        terminal.erase_in_line(terminalpp::terminal::erase_line::all));
+}
+
+TEST_F(a_terminal, can_erase_an_entire_line_to_the_left_of_the_cursor)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[1K"),
+
+        // action
+        terminal.erase_in_line(terminalpp::terminal::erase_line::left));
+}
+
+TEST_F(a_terminal, can_erase_an_entire_line_to_the_right_of_the_cursor)
+{
+    terminalpp::terminal terminal;
+
+    expect_sequence(
+        // str seq actual output,
+        std::string("\x1B[K"),
+
+        // action
+        terminal.erase_in_line(terminalpp::terminal::erase_line::right));
+}

--- a/test/terminal_string_test.cpp
+++ b/test/terminal_string_test.cpp
@@ -1,4 +1,4 @@
-#include "terminalpp/terminal.hpp"
+#include "terminal_test.hpp"
 #include "expect_sequence.hpp"
 #include <gtest/gtest.h>
 
@@ -41,19 +41,6 @@ TEST(terminal_string_test, outputting_another_basic_string_does_not_output_defau
         std::string("abcde"),
         terminal.write("abcde"_ets));
 }
-
-class a_terminal : public testing::Test
-{
-protected:
-    a_terminal()
-    {
-        // Here we stimulate the terminal to output its initial attribute-clear
-        // so that it isn't involved in every other test.
-        terminal_.write(""_ets);
-    }
-
-    terminalpp::terminal terminal_;
-};
 
 TEST_F(a_terminal, changed_charset_outputs_charset_code)
 {

--- a/test/terminal_test.hpp
+++ b/test/terminal_test.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <terminalpp/terminal.hpp>
+#include <terminalpp/string.hpp>
+#include <gtest/gtest.h>
+
+class a_terminal : public testing::Test
+{
+protected:
+    a_terminal()
+    {
+        using namespace terminalpp::literals;
+
+        // Here we stimulate the terminal to output its initial attribute-clear
+        // so that it isn't involved in every other test.
+        terminal_.write(""_ets);
+    }
+
+    terminalpp::terminal terminal_;
+};


### PR DESCRIPTION
Improves coverage by properly testing the erase_in_display and erase_in_line functions of the terminal class.

Also slightly improved those functions by removing a redundant 0 character from the output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/242)
<!-- Reviewable:end -->
