### PR TITLE
Added missing include to for_each_in_region.hpp.

### DIFF
--- a/include/terminalpp/algorithm/for_each_in_region.hpp
+++ b/include/terminalpp/algorithm/for_each_in_region.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "terminalpp/element.hpp"
 #include "terminalpp/rectangle.hpp"
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
It's plausible that for_each_in_region() is called on an object
that yields references to elements, but only has the type forward
declared.  This means that the array access operators fail to
work for the incomplete type.  Therefore, the header must be
included.

Fixes #238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/243)
<!-- Reviewable:end -->
