### PR TITLE
CI Script now downloads lcov 1.15.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,10 @@ jobs:
         if [ ! -f "$HOME/.lcov/local/bin/lcov" ]; then
           mkdir $HOME/.lcov-build || true;
           cd $HOME/.lcov-build;
-          wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.14.orig.tar.gz;
-          tar -xzf lcov_1.14.orig.tar.gz;
+          wget https://github.com/linux-test-project/lcov/releases/download/v1.15/lcov-1.15.tar.gz
+          tar -xzf lcov-1.15.tar.gz;
           mkdir -p $HOME/.lcov || true;
-          DESTDIR=$HOME/.lcov make -C lcov-1.14/ install;
+          DESTDIR=$HOME/.lcov make -C lcov-1.15/ install;
         fi
         echo "##[set-output name=bin;]$(echo $HOME/.lcov/usr/local/bin/lcov)"
       id: lcov


### PR DESCRIPTION
This should interact properly with gcov-9, which is the version that Github Actions is using.

Fixes #254

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/257)
<!-- Reviewable:end -->
