### PR TITLE
Erasing parts of the terminal may leave an attribute trail

### DIFF
--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -308,4 +308,20 @@ void change_attribute(
     wc(sgr_trailer);
 }
 
+//* =========================================================================
+/// \brief Resets the current attribute if necessary.
+//* =========================================================================
+template <class WriteContinuation>
+void change_to_default_attribute(
+    boost::optional<element> &last_element,
+    behaviour const &beh,
+    WriteContinuation &&wc)
+{
+    if (last_element)
+    {
+        detail::change_attribute(last_element->attribute_, {}, beh, wc);
+        last_element->attribute_ = {};
+    }
+}
+
 }}

--- a/include/terminalpp/terminal.hpp
+++ b/include/terminalpp/terminal.hpp
@@ -364,12 +364,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
-        if (state.last_element_)
-        {
-            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
-            state.last_element_->attribute_ = {};
-        }
-
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_all_suffix = {  
@@ -397,12 +392,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
-        if (state.last_element_)
-        {
-            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
-            state.last_element_->attribute_ = {};
-        }
-
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_above_suffix = {  
@@ -430,12 +420,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
-        if (state.last_element_)
-        {
-            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
-            state.last_element_->attribute_ = {};
-        }
-
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_below_suffix = {  
@@ -462,6 +447,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_line_suffix = {  
@@ -489,6 +475,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_line_left_suffix = {  
@@ -516,6 +503,7 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        detail::change_to_default_attribute(state.last_element_, beh, cont);
         detail::csi(beh, cont);
 
         static byte_storage const erase_line_right_suffix = {  

--- a/include/terminalpp/terminal.hpp
+++ b/include/terminalpp/terminal.hpp
@@ -397,6 +397,12 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        if (state.last_element_)
+        {
+            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
+            state.last_element_->attribute_ = {};
+        }
+
         detail::csi(beh, cont);
 
         static byte_storage const erase_above_suffix = {  
@@ -424,6 +430,12 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        if (state.last_element_)
+        {
+            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
+            state.last_element_->attribute_ = {};
+        }
+
         detail::csi(beh, cont);
 
         static byte_storage const erase_below_suffix = {  

--- a/include/terminalpp/terminal.hpp
+++ b/include/terminalpp/terminal.hpp
@@ -364,6 +364,12 @@ public:
         terminalpp::terminal_state &state,
         WriteContinuation &&cont) const
     {
+        if (state.last_element_)
+        {
+            detail::change_attribute(state.last_element_->attribute_, {}, beh, cont);
+            state.last_element_->attribute_ = {};
+        }
+
         detail::csi(beh, cont);
 
         static byte_storage const erase_all_suffix = {  

--- a/test/terminal_erase_test.cpp
+++ b/test/terminal_erase_test.cpp
@@ -10,6 +10,19 @@ TEST_F(a_terminal, can_erase_its_entire_display)
     expect_sequence("\x1B[2J"_tb, result_);
 }
 
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_the_display)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_display();
+    expect_sequence("\x1B[0m\x1B[2J"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_display_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_display();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
+}
 TEST_F(a_terminal, can_erase_its_display_above_the_cursor)
 {
     terminal_.write(append_to_result) << terminalpp::erase_display_above();

--- a/test/terminal_erase_test.cpp
+++ b/test/terminal_erase_test.cpp
@@ -69,14 +69,56 @@ TEST_F(a_terminal, can_erase_its_current_line)
     expect_sequence("\x1B[2K"_tb, result_);
 }
 
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_the_current_line)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_line();
+    expect_sequence("\x1B[0m\x1B[2K"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_the_current_line_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_line();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
+}
+
 TEST_F(a_terminal, can_erase_to_the_left_of_the_cursor)
 {
     terminal_.write(append_to_result) << terminalpp::erase_line_left();
     expect_sequence("\x1B[1K"_tb, result_);
 }
 
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_to_the_left_of_the_current_line)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_line_left();
+    expect_sequence("\x1B[0m\x1B[1K"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_to_the_left_of_the_current_line_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_line_left();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
+}
+
 TEST_F(a_terminal, can_erase_to_the_right_of_the_cursor)
 {
     terminal_.write(append_to_result) << terminalpp::erase_line_right();
     expect_sequence("\x1B[K"_tb, result_);
+}
+
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_to_the_right_of_the_current_line)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_line_right();
+    expect_sequence("\x1B[0m\x1B[K"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_to_the_right_of_the_current_line_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_line_right();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
 }

--- a/test/terminal_erase_test.cpp
+++ b/test/terminal_erase_test.cpp
@@ -29,10 +29,38 @@ TEST_F(a_terminal, can_erase_its_display_above_the_cursor)
     expect_sequence("\x1B[1J"_tb, result_);
 }
 
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_the_display_above)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_display_above();
+    expect_sequence("\x1B[0m\x1B[1J"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_display_above_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_display_above();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
+}
+
 TEST_F(a_terminal, can_erase_its_display_below_the_cursor)
 {
     terminal_.write(append_to_result) << terminalpp::erase_display_below();
     expect_sequence("\x1B[J"_tb, result_);
+}
+
+TEST_F(a_terminal, when_the_attribute_is_non_default_resets_attributes_before_erasing_the_display_below)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets;
+    terminal_.write(append_to_result) << terminalpp::erase_display_below();
+    expect_sequence("\x1B[0m\x1B[J"_tb, result_);
+}
+
+TEST_F(a_terminal, that_erased_display_below_with_non_default_attribute_writes_attributes_afterwards)
+{
+    terminal_.write(discard_result) << "\\[1a"_ets << terminalpp::erase_display_below();
+    terminal_.write(append_to_result) << "\\[1a"_ets;
+    expect_sequence("\x1B[31ma"_tb, result_);
 }
 
 TEST_F(a_terminal, can_erase_its_current_line)


### PR DESCRIPTION
This is apparent when changing the screen size on a Windows PuTTY terminal.  Erasing a screen leaves the entire with a background of the currently-set attribute, whereas on an Ubuntu terminal window, this same operation leaves the screen with the default background.

This change applies a change to the default attribute before erasing any part of the screen.

Fixes #264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/266)
<!-- Reviewable:end -->
