### PR TITLE
Cursor position is reset when a terminal changes its size

### DIFF
--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -18,6 +18,12 @@ terminal::terminal(behaviour const &beh)
 void terminal::set_size(extent size)
 {
     state_.terminal_size_ = size;
+
+    // The cursor positions that terminals have after a size change is
+    // inconsistent across implementations.  By resetting our own position
+    // to an unknown one, it ensures that a precise move occurs the next
+    // time the cursor is moved to a position.
+    state_.cursor_position_ = {};
 }
 
 }

--- a/test/terminal_cursor_test.cpp
+++ b/test/terminal_cursor_test.cpp
@@ -213,3 +213,18 @@ TEST_F(a_terminal, when_restoring_the_cursor_to_a_known_location_remembers_that_
 
     expect_sequence("x"_tb, result_);      
 }
+
+TEST_F(a_terminal, has_an_unknown_cursor_location_when_the_size_is_changed)
+{
+    terminal_.set_size({10, 10});
+    terminal_.write(discard_result) 
+        << terminalpp::move_cursor({8, 8})
+        << "a";
+
+    terminal_.set_size({11, 11});
+    terminal_.write(append_to_result)
+        << terminalpp::move_cursor({9, 8})
+        << "b";
+
+    expect_sequence("\x1B[9;10Hb"_tb, result_);
+}


### PR DESCRIPTION
Fixes #263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/267)
<!-- Reviewable:end -->
