### PR TITLE
Cursor location is now unknown after writing the last character in a line

### DIFF
--- a/include/terminalpp/detail/terminal_writer.hpp
+++ b/include/terminalpp/detail/terminal_writer.hpp
@@ -133,10 +133,11 @@ private:
         {
             if (++state.cursor_position_->x_ == state.terminal_size_.width_)
             {
-                state.cursor_position_->x_ = 0;
-                state.cursor_position_->y_ = std::min(
-                    ++state.cursor_position_->y_, 
-                    state.terminal_size_.height_ - 1);
+                // Terminals differ in their behaviour when reaching the
+                // end of the line.  Some wrap to the next line, some bounce
+                // against the edge.  To maintain consistency, forget the
+                // current cursor position.
+                state.cursor_position_ = {};
             }
         }
     }

--- a/test/terminal_cursor_test.cpp
+++ b/test/terminal_cursor_test.cpp
@@ -228,3 +228,17 @@ TEST_F(a_terminal, has_an_unknown_cursor_location_when_the_size_is_changed)
 
     expect_sequence("\x1B[9;10Hb"_tb, result_);
 }
+
+TEST_F(a_terminal, has_an_unknown_cursor_location_when_writing_the_last_character_in_a_line)
+{
+    terminal_.set_size({10, 10});
+    terminal_.write(discard_result)
+        << terminalpp::move_cursor({9, 0})
+        << "a";
+
+    terminal_.write(append_to_result)
+        << terminalpp::move_cursor({0, 1})
+        << "b";
+
+    expect_sequence("\x1B[2Hb"_tb, result_);
+}

--- a/test/terminal_string_test.cpp
+++ b/test/terminal_string_test.cpp
@@ -222,16 +222,6 @@ static write_position_data const write_position_data_table[] = {
     write_position_data{ {0, 0}, "x"_ets,               {1, 0} },
     write_position_data{ {0, 0}, "abcde"_ets,           {5, 0} },
     write_position_data{ {2, 3}, "abcde"_ets,           {7, 3} },
-
-    // Writing past the terminal width moves the cursor to the next line
-    write_position_data{ {9, 0}, "x"_ets,               {0, 1} },
-    write_position_data{ {9, 0}, "xyz"_ets,             {2, 1} },
-    write_position_data{ {8, 7}, "abcdefghijlkmno"_ets, {3, 9} },
-
-    // Writing past the last line scrolls the terminal, meaning that the
-    // the cursor wraps to the last line again.
-    write_position_data{ {9, 9}, "x"_ets,               {0, 9} },
-
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Since different terminals behave differently at the end of a line (either by wrapping or not), forgetting the current position allows all terminals to behave similarly.

Fixes #265

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/268)
<!-- Reviewable:end -->
