### PR TITLE
Changed some constexpr for const.

### DIFF
--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -90,7 +90,7 @@ void designate_g0_charset(
     behaviour const &terminal_behaviour,
     WriteContinuation &&wc)
 {
-    static constexpr bytes select_g0_charset = {
+    static bytes const select_g0_charset = {
         std::cbegin(ansi::set_charset_g0),
         std::cend(ansi::set_charset_g0)
     };
@@ -105,7 +105,7 @@ void designate_g0_charset(
 template <class WriteContinuation>
 void select_utf8_charset(WriteContinuation &&wc)
 {
-    static constexpr bytes select_utf8_charset_command = {
+    static bytes const select_utf8_charset_command = {
         std::cbegin(ansi::select_utf8_character_set),
         std::cend(ansi::select_utf8_character_set)
     };
@@ -119,7 +119,7 @@ void select_utf8_charset(WriteContinuation &&wc)
 template <class WriteContinuation>
 void select_default_charset(WriteContinuation &&wc)
 {
-    static constexpr bytes select_default_charset_command = {
+    static bytes const select_default_charset_command = {
         std::cbegin(ansi::select_default_character_set),
         std::cend(ansi::select_default_character_set)
     };


### PR DESCRIPTION
g++ 5.4 does not recognize these as valid constexpr constants yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/272)
<!-- Reviewable:end -->
