### PR TITLE
Applied several fixes for Clang 5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ target_compile_options(terminalpp
         $<$<CXX_COMPILER_ID:MSVC>:/WX>
 
         # Add warnings on g++ and Clang
-        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Wsign-conversion -Werror>
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Wsign-conversion -Werror -Wno-tautological-compare>
 )
 
 generate_export_header(terminalpp

--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -20,7 +20,7 @@ namespace terminalpp { namespace detail {
 /// \brief Returns the CSI code for the given behaviour
 //* =========================================================================
 template <class WriteContinuation>
-void csi(behaviour const &terminal_behaviour, WriteContinuation &&wc)
+void csi(behaviour const &/*terminal_behaviour*/, WriteContinuation &&wc)
 {
     wc({
         std::cbegin(ansi::control7::csi),
@@ -31,7 +31,7 @@ void csi(behaviour const &terminal_behaviour, WriteContinuation &&wc)
 /// \brief Returns the OSC code for the given behaviour
 //* =========================================================================
 template <class WriteContinuation>
-void osc(behaviour const &terminal_behaviour, WriteContinuation &&wc)
+void osc(behaviour const &/*terminal_behaviour*/, WriteContinuation &&wc)
 {
     wc({
         std::cbegin(ansi::control7::osc),
@@ -42,7 +42,7 @@ void osc(behaviour const &terminal_behaviour, WriteContinuation &&wc)
 /// \brief Returns the ST code for the given behaviour
 //* =========================================================================
 template <class WriteContinuation>
-void st(behaviour const &terminal_behaviour, WriteContinuation &&wc)
+void st(behaviour const &/*terminal_behaviour*/, WriteContinuation &&wc)
 {
     wc({
         std::cbegin(ansi::control7::st),
@@ -87,7 +87,7 @@ void default_attribute(
 template <class WriteContinuation>
 void designate_g0_charset(
     character_set const &set, 
-    behaviour const &terminal_behaviour,
+    behaviour const &/*terminal_behaviour*/,
     WriteContinuation &&wc)
 {
     static bytes const select_g0_charset = {

--- a/include/terminalpp/detail/terminal_reader.hpp
+++ b/include/terminalpp/detail/terminal_reader.hpp
@@ -27,7 +27,7 @@ public:
     //* =====================================================================
     template <class ReadContinuation>
     void operator()(
-        terminalpp::behaviour const &beh,
+        terminalpp::behaviour const &/*beh*/,
         terminalpp::terminal_state &state,
         ReadContinuation &&cont) const
     {

--- a/include/terminalpp/glyph.hpp
+++ b/include/terminalpp/glyph.hpp
@@ -79,7 +79,7 @@ public:
     {
         for (size_t index = 0; index < sizeof(ucharacter_); ++index)
         {
-            ucharacter_[index] = ustr[index];
+            ucharacter_[index] = static_cast<byte>(ustr[index]);
 
             if (!(ucharacter_[index] & 0x80))
             {

--- a/include/terminalpp/terminal.hpp
+++ b/include/terminalpp/terminal.hpp
@@ -528,7 +528,7 @@ public:
     template <class WriteContinuation>
     void operator()(
         terminalpp::behaviour const &beh,
-        terminalpp::terminal_state &state,
+        terminalpp::terminal_state &/*state*/,
         WriteContinuation &&cont) const
     {
         if (beh.supports_basic_mouse_tracking)
@@ -567,7 +567,7 @@ public:
     template <class WriteContinuation>
     void operator()(
         terminalpp::behaviour const &beh,
-        terminalpp::terminal_state &state,
+        terminalpp::terminal_state &/*state*/,
         WriteContinuation &&cont) const
     {
         if (beh.supports_basic_mouse_tracking)
@@ -611,7 +611,7 @@ public:
     template <class WriteContinuation>
     void operator()(
         terminalpp::behaviour const &beh,
-        terminalpp::terminal_state &state,
+        terminalpp::terminal_state &/*state*/,
         WriteContinuation &&cont) const
     {
         static byte_storage const set_window_title_prefix = {
@@ -663,7 +663,7 @@ public:
     template <class WriteContinuation>
     void operator()(
         terminalpp::behaviour const &beh,
-        terminalpp::terminal_state &state,
+        terminalpp::terminal_state &/*state*/,
         WriteContinuation &&cont) const
     {
         detail::dec_pm(beh, cont);
@@ -691,7 +691,7 @@ public:
     template <class WriteContinuation>
     void operator()(
         terminalpp::behaviour const &beh,
-        terminalpp::terminal_state &state,
+        terminalpp::terminal_state &/*state*/,
         WriteContinuation &&cont) const
     {
         detail::dec_pm(beh, cont);

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -91,7 +91,7 @@ void canvas::resize(extent const &size)
 
     for_each_in_region(
         *this, {{}, {min_width, min_height}},
-        [this, &size, &new_grid](
+        [&size, &new_grid](
             element const &elem, coordinate_type column, coordinate_type row)
         {
              auto const new_grid_pos = std::vector<element>::size_type(


### PR DESCRIPTION
Clang is a little more peculiar about the warnings for unused function
arguments, etc.  Also disabled the tautological compare warning since
it was comparing with a variable that happened to be 0, but that requires
knowledge beyond that which is available to the function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/273)
<!-- Reviewable:end -->
