### PR TITLE
Udl for single elements#189

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ target_sources(terminalpp_tester
         test/control_sequence_test.cpp
         test/effect_test.cpp
         test/element_test.cpp
+        test/element_udl_test.cpp
         test/encoder_test.cpp
         test/expect_sequence.cpp
         test/extent_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ target_compile_options(terminalpp
         $<$<CXX_COMPILER_ID:MSVC>:/WX>
 
         # Add warnings on g++ and Clang
-        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Wsign-conversion -Werror -Wno-tautological-compare>
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Wsign-conversion -Werror -Wno-tautological-compare -Wno-unused-parameter>
 )
 
 generate_export_header(terminalpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ target_sources(terminalpp
         include/terminalpp/version.hpp
         include/terminalpp/virtual_key.hpp
 
+        src/detail/element_udl.cpp
         src/detail/parser.cpp
         src/detail/well_known_virtual_key.cpp
         src/attribute.cpp

--- a/include/terminalpp/element.hpp
+++ b/include/terminalpp/element.hpp
@@ -82,14 +82,15 @@ TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, element const &elem);
 
 namespace detail {
-element parse_element(gsl::cstring_span text);
+element parse_element(gsl::cstring_span &text);
 }
 
 inline namespace literals {
 
 inline element operator ""_ete(char const *text, std::size_t len)
 {
-    return detail::parse_element(gsl::cstring_span(text, len));
+    gsl::cstring_span data(text, len);
+    return detail::parse_element(data);
 }
 
 }}

--- a/include/terminalpp/element.hpp
+++ b/include/terminalpp/element.hpp
@@ -80,7 +80,14 @@ constexpr bool operator==(element const &lhs, element const &rhs)
 TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, element const &elem);
 
+inline namespace literals {
+
+constexpr element operator ""_elem(char const */*text*/, std::size_t /*len*/)
+{
+    return element{};
 }
+
+}}
 
 namespace std {
 

--- a/include/terminalpp/element.hpp
+++ b/include/terminalpp/element.hpp
@@ -82,6 +82,7 @@ TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, element const &elem);
 
 namespace detail {
+TERMINALPP_EXPORT
 element parse_element(gsl::cstring_span &text);
 }
 

--- a/include/terminalpp/element.hpp
+++ b/include/terminalpp/element.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "terminalpp/core.hpp"
 #include "terminalpp/attribute.hpp"
 #include "terminalpp/glyph.hpp"
 #include <boost/container_hash/hash.hpp>
@@ -80,11 +81,15 @@ constexpr bool operator==(element const &lhs, element const &rhs)
 TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, element const &elem);
 
+namespace detail {
+element parse_element(gsl::cstring_span text);
+}
+
 inline namespace literals {
 
-constexpr element operator ""_elem(char const */*text*/, std::size_t /*len*/)
+inline element operator ""_ete(char const *text, std::size_t len)
 {
-    return element{};
+    return detail::parse_element(gsl::cstring_span(text, len));
 }
 
 }}

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -93,6 +93,34 @@ struct modify_intensity
     element &elem_;
 };
 
+struct modify_polarity
+{
+    modify_polarity(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(char ch) const
+    {
+        switch(ch)
+        {
+            case '+':
+                elem_.attribute_.polarity_ = graphics::polarity::positive;
+                break;
+
+            case '-':
+                elem_.attribute_.polarity_ = graphics::polarity::negative;
+                break;
+
+            default:
+                elem_.attribute_.polarity_ = graphics::polarity::positive;
+                break;
+        }
+    }
+
+    element &elem_;
+};
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -104,7 +132,8 @@ element parse_element(gsl::cstring_span &text)
     auto const character_code_p = qi::lit('C') >> (uint3_3_p | qi::attr((unsigned char)(' ')));
     auto const extended_character_set_p = qi::lit('c') >> qi::lit('%') >> qi::char_;
     auto const character_set_p = qi::lit('c') >> qi::char_;
-    auto const intensity_p = qi::lit('i') >> qi::char_("<>=x");
+    auto const intensity_p = qi::lit('i') >> qi::char_;
+    auto const polarity_p = qi::lit('p') >> qi::char_;
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
@@ -114,6 +143,7 @@ element parse_element(gsl::cstring_span &text)
            | extended_character_set_p[modify_extended_charset(elem)] >> expression
            | character_set_p[modify_charset(elem)] >> expression
            | intensity_p[modify_intensity(elem)] >> expression
+           | polarity_p[modify_polarity(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )
         )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -40,10 +40,11 @@ enum class parser_state {
 struct parser_info
 {
     parser_state state {parser_state::idle};
-    byte charcode;
-    byte red, green;
-    byte greyscale;
-    uint16_t utf8;
+    byte charcode{0};
+    byte red{0};
+    byte green{0};
+    byte greyscale{0};
+    uint16_t utf8{0};
 };
 
 byte digit10_to_byte(char const ch)

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -65,6 +65,29 @@ struct modify_extended_charset
     element &elem_;
 };
 
+struct modify_intensity
+{
+    modify_intensity(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(char ch) const
+    {
+        switch(ch)
+        {
+            case '>':
+                elem_.attribute_.intensity_ = graphics::intensity::bold;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    element &elem_;
+};
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -76,6 +99,7 @@ element parse_element(gsl::cstring_span &text)
     auto const character_code_p = qi::lit('C') >> (uint3_3_p | qi::attr((unsigned char)(' ')));
     auto const extended_character_set_p = qi::lit('c') >> qi::lit('%') >> qi::char_;
     auto const character_set_p = qi::lit('c') >> qi::char_;
+    auto const intensity_p = qi::lit('i') >> qi::char_("<>=x");
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
@@ -84,6 +108,7 @@ element parse_element(gsl::cstring_span &text)
           -( character_code_p[modify_element(elem)]
            | extended_character_set_p[modify_extended_charset(elem)] >> expression
            | character_set_p[modify_charset(elem)] >> expression
+           | intensity_p[modify_intensity(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )
         )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -1,4 +1,5 @@
 #include "terminalpp/element.hpp"
+#include "terminalpp/character_set.hpp"
 #include <boost/spirit/include/qi.hpp>
 
 namespace terminalpp {
@@ -8,7 +9,7 @@ namespace qi = boost::spirit::qi;
 
 struct modify_element
 {
-    modify_element(element& elem)
+    modify_element(element &elem)
       : elem_(elem)
     {
     }
@@ -28,6 +29,27 @@ struct modify_element
     element &elem_;
 };
 
+struct modify_charset
+{
+    modify_charset(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(char ch) const
+    {
+        byte const charset_code[] = { static_cast<byte>(ch) };
+        auto const charset = lookup_character_set(charset_code);
+
+        if (charset)
+        {
+            elem_.glyph_.charset_ = *charset;
+        }
+    }
+
+    element &elem_;
+};
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -37,17 +59,20 @@ element parse_element(gsl::cstring_span &text)
 
     auto const uint3_3_p = qi::uint_parser<unsigned char, 10, 3, 3>();
     auto const character_code_p = qi::lit('C') >> (uint3_3_p | qi::attr((unsigned char)(' ')));
+    auto const character_set_p = qi::lit('c') >> qi::char_;
 
-    qi::parse(
-        first, 
-        last,
+    auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
+
+    expression = 
         (qi::lit('\\') >> 
           -( character_code_p[modify_element(elem)]
+           | character_set_p[modify_charset(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )
         )
-      | (qi::char_[modify_element(elem)])
-    );
+      | (qi::char_[modify_element(elem)]);
+
+    qi::parse(first, last, expression);
 
     return elem;
 }

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -200,6 +200,58 @@ struct modify_foreground_greyscale_colour
     element &elem_;
 };
 
+
+struct modify_background_low_colour
+{
+    modify_background_low_colour(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(unsigned char col) const
+    {
+        elem_.attribute_.background_colour_ = low_colour(
+            static_cast<terminalpp::graphics::colour>(col));
+    }
+
+    element &elem_;
+};
+
+struct modify_background_high_colour
+{
+    modify_background_high_colour(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(boost::fusion::vector<
+        unsigned char, unsigned char, unsigned char> col) const
+    {
+        elem_.attribute_.background_colour_ = high_colour(
+            boost::fusion::at<boost::mpl::int_<0>>(col),
+            boost::fusion::at<boost::mpl::int_<1>>(col),
+            boost::fusion::at<boost::mpl::int_<2>>(col));
+    }
+
+    element &elem_;
+};
+
+struct modify_background_greyscale_colour
+{
+    modify_background_greyscale_colour(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(unsigned char col) const
+    {
+        elem_.attribute_.background_colour_ = greyscale_colour(col);
+    }
+
+    element &elem_;
+};
+
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -220,6 +272,9 @@ element parse_element(gsl::cstring_span &text)
     auto const foreground_low_colour = qi::lit('[') >> uint1_1_p;
     auto const foreground_high_colour = qi::lit('<') >> uint1_1_p >> uint1_1_p >> uint1_1_p;
     auto const foreground_greyscale_colour = qi::lit('{') >> uint2_2_p;
+    auto const background_low_colour = qi::lit(']') >> uint1_1_p;
+    auto const background_high_colour = qi::lit('>') >> uint1_1_p >> uint1_1_p >> uint1_1_p;
+    auto const background_greyscale_colour = qi::lit('}') >> uint2_2_p;
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
@@ -234,6 +289,9 @@ element parse_element(gsl::cstring_span &text)
            | foreground_low_colour[modify_foreground_low_colour(elem)] >> expression
            | foreground_high_colour[modify_foreground_high_colour(elem)] >> expression
            | foreground_greyscale_colour[modify_foreground_greyscale_colour(elem)] >> expression
+           | background_low_colour[modify_background_low_colour(elem)] >> expression
+           | background_high_colour[modify_background_high_colour(elem)] >> expression
+           | background_greyscale_colour[modify_background_greyscale_colour(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )
         )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -121,6 +121,34 @@ struct modify_polarity
     element &elem_;
 };
 
+struct modify_underlining
+{
+    modify_underlining(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(char ch) const
+    {
+        switch(ch)
+        {
+            case '+':
+                elem_.attribute_.underlining_ = graphics::underlining::underlined;
+                break;
+
+            case '-':
+                elem_.attribute_.underlining_ = graphics::underlining::not_underlined;
+                break;
+
+            default:
+                elem_.attribute_.underlining_ = graphics::underlining::not_underlined;
+                break;
+        }
+    }
+
+    element &elem_;
+};
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -134,6 +162,7 @@ element parse_element(gsl::cstring_span &text)
     auto const character_set_p = qi::lit('c') >> qi::char_;
     auto const intensity_p = qi::lit('i') >> qi::char_;
     auto const polarity_p = qi::lit('p') >> qi::char_;
+    auto const underlining_p = qi::lit('u') >> qi::char_;
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
@@ -144,6 +173,7 @@ element parse_element(gsl::cstring_span &text)
            | character_set_p[modify_charset(elem)] >> expression
            | intensity_p[modify_intensity(elem)] >> expression
            | polarity_p[modify_polarity(elem)] >> expression
+           | underlining_p[modify_underlining(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )
         )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -80,7 +80,12 @@ struct modify_intensity
                 elem_.attribute_.intensity_ = graphics::intensity::bold;
                 break;
 
+            case '<':
+                elem_.attribute_.intensity_ = graphics::intensity::faint;
+                break;
+
             default:
+                elem_.attribute_.intensity_ = graphics::intensity::normal;
                 break;
         }
     }

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -1,0 +1,25 @@
+#include "terminalpp/element.hpp"
+
+namespace terminalpp {
+namespace detail {
+
+element parse_element(gsl::cstring_span text)
+{
+    element elem;
+
+    for (auto const ch : text)
+    {
+        switch (ch)
+        {
+        case '\\' :
+            return elem;
+        default:
+            elem.glyph_.character_ = static_cast<byte>(text[0]);
+            return elem;
+        }
+    }
+
+    return elem;
+}
+
+}}

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -1,5 +1,6 @@
 #include "terminalpp/element.hpp"
 #include "terminalpp/character_set.hpp"
+#include "terminalpp/ansi/charset.hpp"
 #include <boost/spirit/include/qi.hpp>
 
 namespace terminalpp {
@@ -16,14 +17,7 @@ struct modify_element
 
     void operator()(char ch) const
     {
-        printf("assign char %c\n", ch);
         elem_.glyph_.character_ = static_cast<byte>(ch);
-    }
-
-    void operator()(unsigned char ch) const
-    {
-        printf("assign uchar %ch\n", char(ch));
-        elem_.glyph_.character_ = static_cast<byte>(ch);        
     }
 
     element &elem_;
@@ -50,6 +44,27 @@ struct modify_charset
     element &elem_;
 };
 
+struct modify_extended_charset
+{
+    modify_extended_charset(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()(char ch) const
+    {
+        byte const charset_code[] = { ansi::charset_extender, static_cast<byte>(ch) };
+        auto const charset = lookup_character_set(charset_code);
+
+        if (charset)
+        {
+            elem_.glyph_.charset_ = *charset;
+        }
+    }
+
+    element &elem_;
+};
+
 element parse_element(gsl::cstring_span &text)
 {
     auto first = text.cbegin();
@@ -59,6 +74,7 @@ element parse_element(gsl::cstring_span &text)
 
     auto const uint3_3_p = qi::uint_parser<unsigned char, 10, 3, 3>();
     auto const character_code_p = qi::lit('C') >> (uint3_3_p | qi::attr((unsigned char)(' ')));
+    auto const extended_character_set_p = qi::lit('c') >> qi::lit('%') >> qi::char_;
     auto const character_set_p = qi::lit('c') >> qi::char_;
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
@@ -66,6 +82,7 @@ element parse_element(gsl::cstring_span &text)
     expression = 
         (qi::lit('\\') >> 
           -( character_code_p[modify_element(elem)]
+           | extended_character_set_p[modify_extended_charset(elem)] >> expression
            | character_set_p[modify_charset(elem)] >> expression
            | (qi::char_[modify_element(elem)])
            )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -3,19 +3,63 @@
 namespace terminalpp {
 namespace detail {
 
-element parse_element(gsl::cstring_span text)
+enum class parse_state
+{
+    idle,
+    escape,
+    done,
+};
+
+namespace {
+
+parse_state parse_idle(element &elem, char ch)
+{
+    switch (ch)
+    {
+        case '\\':
+            return parse_state::escape;
+        default:
+            elem.glyph_.character_ = static_cast<byte>(ch);
+            return parse_state::done;
+    }
+}
+
+parse_state parse_escape(element &elem, char ch)
+{
+    elem.glyph_.character_ = static_cast<byte>(ch);
+    return parse_state::done;
+}
+
+}
+
+element parse_element(gsl::cstring_span &text)
 {
     element elem;
+    auto state = parse_state::idle;
 
-    for (auto const ch : text)
+    while(!text.empty())
     {
-        switch (ch)
+        auto const ch = text[0];
+
+        switch(state)
         {
-        case '\\' :
-            return elem;
-        default:
-            elem.glyph_.character_ = static_cast<byte>(text[0]);
-            return elem;
+            case parse_state::idle:
+                state = parse_idle(elem, ch);
+                break;
+
+            case parse_state::escape:
+                state = parse_escape(elem, ch);
+                break;
+
+            default:
+                break;
+        }
+
+        text = text.subspan(1);
+
+        if (state == parse_state::done)
+        {
+            break;
         }
     }
 

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -251,6 +251,21 @@ struct modify_background_greyscale_colour
     element &elem_;
 };
 
+struct reset_element_attributes
+{
+    reset_element_attributes(element &elem)
+      : elem_(elem)
+    {
+    }
+
+    void operator()() const
+    {
+        elem_.attribute_ = {};
+    }
+
+    element &elem_;
+};
+
 struct modify_unicode_element
 {
     modify_unicode_element(element &elem)
@@ -325,6 +340,7 @@ element parse_element(gsl::cstring_span &text)
     auto const background_high_colour = qi::lit('>') >> uint1_1_p >> uint1_1_p >> uint1_1_p;
     auto const background_greyscale_colour = qi::lit('}') >> uint2_2_p;
     auto const unicode_p = qi::lit('U') >> (uint4_4_p | qi::attr((unsigned short)(' ')));
+    auto const reset_attributes_p = qi::lit('x');
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
@@ -344,6 +360,7 @@ element parse_element(gsl::cstring_span &text)
            | background_low_colour[modify_background_low_colour(elem)] >> expression
            | background_high_colour[modify_background_high_colour(elem)] >> expression
            | background_greyscale_colour[modify_background_greyscale_colour(elem)] >> expression
+           | reset_attributes_p[reset_element_attributes(elem)] >> expression
            | unicode_p[modify_unicode_element(elem)]
            | (qi::char_[modify_element(elem)])
            )

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -254,11 +254,6 @@ struct modify_background_greyscale_colour
 
 element parse_element(gsl::cstring_span &text)
 {
-    auto first = text.cbegin();
-    auto last = text.cend();
-
-    element elem;
-
     auto const uint1_1_p = qi::uint_parser<unsigned char, 10, 1, 1>();
     auto const uint2_2_p = qi::uint_parser<unsigned char, 10, 2, 2>();
     auto const uint3_3_p = qi::uint_parser<unsigned char, 10, 3, 3>();
@@ -278,6 +273,8 @@ element parse_element(gsl::cstring_span &text)
 
     auto expression = qi::rule<gsl::cstring_span::const_iterator, element()>{};
 
+    element elem;
+
     expression = 
         (qi::lit('\\') >> 
           -( character_code_p[modify_element(elem)]
@@ -296,6 +293,9 @@ element parse_element(gsl::cstring_span &text)
            )
         )
       | (qi::char_[modify_element(elem)]);
+
+    auto first = text.cbegin();
+    auto last = text.cend();
 
     qi::parse(first, last, expression);
 

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -1,0 +1,11 @@
+#include <terminalpp/element.hpp>
+#include <gtest/gtest.h>
+
+TEST(a, b)
+{
+    using namespace terminalpp::literals;
+    constexpr terminalpp::element expected_element = {};
+    constexpr terminalpp::element elem = ""_elem;
+
+    ASSERT_EQ(expected_element, elem);
+}

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -144,7 +144,7 @@ static udl_element const udl_elements[] = {
     udl_element{"\\[2a"_ete, with_foreground_colour({'a'}, terminalpp::palette::green)},
     udl_element{"\\[3a"_ete, with_foreground_colour({'a'}, terminalpp::palette::olive)},
 
-    // Extras after low foreground colour take precedence
+    // Extras after low foreground colour take precedence.
     udl_element{"\\[2\\[3a"_ete, with_foreground_colour({'a'}, terminalpp::palette::olive)},
     udl_element{"\\[3\\[2a"_ete, with_foreground_colour({'a'}, terminalpp::palette::green)},
 
@@ -153,10 +153,18 @@ static udl_element const udl_elements[] = {
     udl_element{"\\<850a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
     udl_element{"\\<085a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
 
-    // Extras after high foreground colour take precedence
+    // Extras after high foreground colour take precedence.
     udl_element{"\\<850\\<085a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
     udl_element{"\\<085\\<850a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
 
+    // Greyscale foreground colour.
+    udl_element{"\\{00a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{0})},
+    udl_element{"\\{17a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{17})},
+    udl_element{"\\{22a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{22})},
+
+    // Extras after greyscale foreground colour take precedence.
+    udl_element{"\\{17\\{22a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{22})},
+    udl_element{"\\{22\\{17a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{17})},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -34,3 +34,11 @@ TEST(an_element_udl_with_an_escape_slash, returns_a_default_element)
 
     ASSERT_EQ(expected_element, elem);
 }
+
+TEST(an_element_udl_with_a_double_escape_slash, returns_a_backslash_element)
+{
+    terminalpp::element const expected_element = {'\\'};
+    terminalpp::element const elem = "\\\\"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -67,6 +67,15 @@ TEST(an_element_udl_with_a_charset_code, returns_the_element_with_that_charset)
 
     ASSERT_EQ(expected_element, elem);
 }
+
+TEST(an_element_udl_with_an_extended_charset_code, returns_the_element_with_that_charset)
+{
+    terminalpp::element expected_element = {'c'};
+    expected_element.glyph_.charset_ = terminalpp::charset::portuguese;
+    terminalpp::element const elem = "\\c%6c"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
 /*
 TEST(an_element_udl_with_a_high_intensity_and_a_character, returns_an_element_with_that_character_at_high_intensity)
 {

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -1,11 +1,36 @@
 #include <terminalpp/element.hpp>
 #include <gtest/gtest.h>
 
-TEST(a, b)
+using namespace terminalpp::literals;
+
+TEST(an_empty_element_udl, returns_a_default_element)
 {
-    using namespace terminalpp::literals;
-    constexpr terminalpp::element expected_element = {};
-    constexpr terminalpp::element elem = ""_elem;
+    terminalpp::element const expected_element = {};
+    terminalpp::element const elem = ""_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+
+TEST(an_element_udl_with_a_character, returns_the_character)
+{
+    terminalpp::element const expected_element = {'x'};
+    terminalpp::element const elem = "x"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+
+TEST(an_element_udl_with_multiple_characters, returns_the_first_character)
+{
+    terminalpp::element const expected_element = {'x'};
+    terminalpp::element const elem = "xyz"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+
+TEST(an_element_udl_with_an_escape_slash, returns_a_default_element)
+{
+    terminalpp::element const expected_element = {};
+    terminalpp::element const elem = "\\"_ete;
 
     ASSERT_EQ(expected_element, elem);
 }

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -42,3 +42,30 @@ TEST(an_element_udl_with_a_double_escape_slash, returns_a_backslash_element)
 
     ASSERT_EQ(expected_element, elem);
 }
+
+TEST(an_element_udl_with_an_unfinished_character_code, returns_a_default_element)
+{
+    terminalpp::element const expected_element = {};
+    terminalpp::element const elem = "\\C09"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+
+TEST(an_element_udl_with_a_character_code, returns_an_element_with_that_character)
+{
+    terminalpp::element const expected_element = {'a'};
+    terminalpp::element const elem = "\\C097"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+
+/*
+TEST(an_element_udl_with_a_high_intensity_and_a_character, returns_an_element_with_that_character_at_high_intensity)
+{
+    terminalpp::element expected_element = {'x'};
+    expected_element.attribute_.intensity_ = terminalpp::graphics::intensity::bold;
+    terminalpp::element const elem = "\\i+x"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
+*/

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -209,6 +209,11 @@ static udl_element const udl_elements[] = {
     udl_element{"\\U0057"_ete, terminalpp::element{terminalpp::glyph{"\x57"}}},
     udl_element{"\\U16B8"_ete, terminalpp::element{terminalpp::glyph{"\xE1\x9A\xB8"}}},
 
+    // Multiple characters after a unicode character are ignored.
+    udl_element{"\\U010Ex"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},
+    udl_element{"\\U010E\\C097"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},
+    udl_element{"\\U010E\\U16B8"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},
+
     // Default code removes all attributes
     udl_element{"\\>201\\{22\\p-\\u+\\xa"_ete, terminalpp::element{'a'}},
 };

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -45,6 +45,12 @@ terminalpp::element with_polarity(terminalpp::element elem, terminalpp::graphics
     return elem;
 }
 
+terminalpp::element with_underlining(terminalpp::element elem, terminalpp::graphics::underlining underlining)
+{
+    elem.attribute_.underlining_ = underlining;
+    return elem;
+}
+
 }
 
 static udl_element const udl_elements[] = {
@@ -114,9 +120,18 @@ static udl_element const udl_elements[] = {
     udl_element{"\\p-a"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::negative)},
     udl_element{"\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
 
-    // Extras after the polarity take precedence.
+    // Extras after polarity take precedence.
     udl_element{"\\p+\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
     udl_element{"\\p-\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
+
+    // Underlining
+    udl_element{"\\u+a"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::underlined)},
+    udl_element{"\\u-a"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
+    udl_element{"\\uxa"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
+
+    // Extras after underlining take precedence.
+    udl_element{"\\u+\\uxa"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
+    udl_element{"\\u-\\uxa"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -147,6 +147,16 @@ static udl_element const udl_elements[] = {
     // Extras after low foreground colour take precedence
     udl_element{"\\[2\\[3a"_ete, with_foreground_colour({'a'}, terminalpp::palette::olive)},
     udl_element{"\\[3\\[2a"_ete, with_foreground_colour({'a'}, terminalpp::palette::green)},
+
+    // High foreground colour.
+    udl_element{"\\<000a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{0, 0, 0})},
+    udl_element{"\\<850a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
+    udl_element{"\\<085a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
+
+    // Extras after high foreground colour take precedence
+    udl_element{"\\<850\\<085a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
+    udl_element{"\\<085\\<850a"_ete, with_foreground_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
+
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -59,6 +59,14 @@ TEST(an_element_udl_with_a_character_code, returns_an_element_with_that_characte
     ASSERT_EQ(expected_element, elem);
 }
 
+TEST(an_element_udl_with_a_charset_code, returns_the_element_with_that_charset)
+{
+    terminalpp::element expected_element = {'b'};
+    expected_element.glyph_.charset_ = terminalpp::charset::dec;
+    terminalpp::element const elem = "\\c0b"_ete;
+
+    ASSERT_EQ(expected_element, elem);
+}
 /*
 TEST(an_element_udl_with_a_high_intensity_and_a_character, returns_an_element_with_that_character_at_high_intensity)
 {

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -199,10 +199,10 @@ static udl_element const udl_elements[] = {
     udl_element{"\\}22\\}17a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{17})},
 
     // Incomplete unicode character codes return a default character.
-    udl_element{"\\U"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
-    udl_element{"\\U0"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
-    udl_element{"\\U01"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
-    udl_element{"\\U010"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
+    udl_element{"\\U"_ete, terminalpp::element{}},
+    udl_element{"\\U0"_ete, terminalpp::element{}},
+    udl_element{"\\U01"_ete, terminalpp::element{}},
+    udl_element{"\\U010"_ete, terminalpp::element{}},
 
     // Complete unicode character code returns a unicode character.
     udl_element{"\\U010E"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -62,6 +62,10 @@ static udl_element const udl_elements[] = {
     // A double escape character returns a backslash.
     udl_element{"\\\\"_ete, terminalpp::element{'\\'}},
 
+    // Extras after the slash are ignored.
+    udl_element{"\\\\\\"_ete, terminalpp::element{'\\'}},
+    udl_element{"\\\\\\\\"_ete, terminalpp::element{'\\'}},
+
     // Unfinished character codes return a default character.
     udl_element{"\\C"_ete, terminalpp::element{}},
     udl_element{"\\C0"_ete, terminalpp::element{}},
@@ -69,6 +73,13 @@ static udl_element const udl_elements[] = {
 
     // A complete character code returns that character.
     udl_element{"\\C097"_ete, terminalpp::element{'a'}},
+
+    // Extras after the code are ignored.
+    udl_element("\\C098\\"_ete, terminalpp::element{'b'}),
+    udl_element("\\C098\\C"_ete, terminalpp::element{'b'}),
+    udl_element("\\C098\\C0"_ete, terminalpp::element{'b'}),
+    udl_element("\\C098\\C09"_ete, terminalpp::element{'b'}),
+    udl_element("\\C098\\C098"_ete, terminalpp::element{'b'}),
 
     // Charset codes
     udl_element{"\\c0a"_ete, with_charset({'a'}, terminalpp::charset::dec)},
@@ -78,8 +89,19 @@ static udl_element const udl_elements[] = {
     udl_element{"\\c%6x"_ete, with_charset({'x'}, terminalpp::charset::portuguese)},
     udl_element{"\\c%5j"_ete, with_charset({'j'}, terminalpp::charset::dec_supplementary_graphics)},
 
+    // Extras after the code take precedence
+    udl_element{"\\c0\\c%5d"_ete, with_charset({'d'}, terminalpp::charset::dec_supplementary_graphics)},
+
     // Intensity
     udl_element{"\\i>a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::bold)},
+    udl_element{"\\i<a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::faint)},
+    udl_element{"\\i=a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
+    udl_element{"\\ixa"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
+
+    // Extras after the intensity take precedence.
+    udl_element{"\\i>\\i<a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::faint)},
+    udl_element{"\\i>\\ixa"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
+    udl_element{"\\i>\\i=a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -39,6 +39,12 @@ terminalpp::element with_intensity(terminalpp::element elem, terminalpp::graphic
     return elem;
 }
 
+terminalpp::element with_polarity(terminalpp::element elem, terminalpp::graphics::polarity polarity)
+{
+    elem.attribute_.polarity_ = polarity;
+    return elem;
+}
+
 }
 
 static udl_element const udl_elements[] = {
@@ -102,6 +108,15 @@ static udl_element const udl_elements[] = {
     udl_element{"\\i>\\i<a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::faint)},
     udl_element{"\\i>\\ixa"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
     udl_element{"\\i>\\i=a"_ete, with_intensity({'a'}, terminalpp::graphics::intensity::normal)},
+
+    // Polarity
+    udl_element{"\\p+a"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
+    udl_element{"\\p-a"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::negative)},
+    udl_element{"\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
+
+    // Extras after the polarity take precedence.
+    udl_element{"\\p+\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
+    udl_element{"\\p-\\pxa"_ete, with_polarity({'a'}, terminalpp::graphics::polarity::positive)},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -1,4 +1,5 @@
 #include <terminalpp/element.hpp>
+#include <terminalpp/palette.hpp>
 #include <gtest/gtest.h>
 #include <utility>
 
@@ -48,6 +49,12 @@ terminalpp::element with_polarity(terminalpp::element elem, terminalpp::graphics
 terminalpp::element with_underlining(terminalpp::element elem, terminalpp::graphics::underlining underlining)
 {
     elem.attribute_.underlining_ = underlining;
+    return elem;
+}
+
+terminalpp::element with_foreground_colour(terminalpp::element elem, terminalpp::colour col)
+{
+    elem.attribute_.foreground_colour_ = col;
     return elem;
 }
 
@@ -132,6 +139,14 @@ static udl_element const udl_elements[] = {
     // Extras after underlining take precedence.
     udl_element{"\\u+\\uxa"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
     udl_element{"\\u-\\uxa"_ete, with_underlining({'a'}, terminalpp::graphics::underlining::not_underlined)},
+
+    // Low foreground colour.
+    udl_element{"\\[2a"_ete, with_foreground_colour({'a'}, terminalpp::palette::green)},
+    udl_element{"\\[3a"_ete, with_foreground_colour({'a'}, terminalpp::palette::olive)},
+
+    // Extras after low foreground colour take precedence
+    udl_element{"\\[2\\[3a"_ete, with_foreground_colour({'a'}, terminalpp::palette::olive)},
+    udl_element{"\\[3\\[2a"_ete, with_foreground_colour({'a'}, terminalpp::palette::green)},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -197,6 +197,17 @@ static udl_element const udl_elements[] = {
     // Extras after greyscale background colour take precedence.
     udl_element{"\\}17\\}22a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{22})},
     udl_element{"\\}22\\}17a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{17})},
+
+    // Incomplete unicode character codes return a default character.
+    udl_element{"\\U"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
+    udl_element{"\\U0"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
+    udl_element{"\\U01"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
+    udl_element{"\\U010"_ete, terminalpp::element{{' ', terminalpp::charset::utf8}}},
+
+    // Complete unicode character code returns a unicode character.
+    udl_element{"\\U010E"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},
+    udl_element{"\\U0057"_ete, terminalpp::element{terminalpp::glyph{"\x57"}}},
+    udl_element{"\\U16B8"_ete, terminalpp::element{terminalpp::glyph{"\xE1\x9A\xB8"}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -208,6 +208,9 @@ static udl_element const udl_elements[] = {
     udl_element{"\\U010E"_ete, terminalpp::element{terminalpp::glyph{"\xC4\x8E"}}},
     udl_element{"\\U0057"_ete, terminalpp::element{terminalpp::glyph{"\x57"}}},
     udl_element{"\\U16B8"_ete, terminalpp::element{terminalpp::glyph{"\xE1\x9A\xB8"}}},
+
+    // Default code removes all attributes
+    udl_element{"\\>201\\{22\\p-\\u+\\xa"_ete, terminalpp::element{'a'}},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -76,13 +76,12 @@ TEST(an_element_udl_with_an_extended_charset_code, returns_the_element_with_that
 
     ASSERT_EQ(expected_element, elem);
 }
-/*
+
 TEST(an_element_udl_with_a_high_intensity_and_a_character, returns_an_element_with_that_character_at_high_intensity)
 {
     terminalpp::element expected_element = {'x'};
     expected_element.attribute_.intensity_ = terminalpp::graphics::intensity::bold;
-    terminalpp::element const elem = "\\i+x"_ete;
+    terminalpp::element const elem = "\\i>x"_ete;
 
     ASSERT_EQ(expected_element, elem);
 }
-*/

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -58,6 +58,12 @@ terminalpp::element with_foreground_colour(terminalpp::element elem, terminalpp:
     return elem;
 }
 
+terminalpp::element with_background_colour(terminalpp::element elem, terminalpp::colour col)
+{
+    elem.attribute_.background_colour_ = col;
+    return elem;
+}
+
 }
 
 static udl_element const udl_elements[] = {
@@ -165,6 +171,32 @@ static udl_element const udl_elements[] = {
     // Extras after greyscale foreground colour take precedence.
     udl_element{"\\{17\\{22a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{22})},
     udl_element{"\\{22\\{17a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{17})},
+//
+    // Low background colour.
+    udl_element{"\\]2a"_ete, with_background_colour({'a'}, terminalpp::palette::green)},
+    udl_element{"\\]3a"_ete, with_background_colour({'a'}, terminalpp::palette::olive)},
+
+    // Extras after low background colour take precedence.
+    udl_element{"\\]2\\]3a"_ete, with_background_colour({'a'}, terminalpp::palette::olive)},
+    udl_element{"\\]3\\]2a"_ete, with_background_colour({'a'}, terminalpp::palette::green)},
+
+    // High background colour.
+    udl_element{"\\>000a"_ete, with_background_colour({'a'}, terminalpp::high_colour{0, 0, 0})},
+    udl_element{"\\>850a"_ete, with_background_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
+    udl_element{"\\>085a"_ete, with_background_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
+
+    // Extras after high background colour take precedence.
+    udl_element{"\\>850\\>085a"_ete, with_background_colour({'a'}, terminalpp::high_colour{0, 8, 5})},
+    udl_element{"\\>085\\>850a"_ete, with_background_colour({'a'}, terminalpp::high_colour{8, 5, 0})},
+
+    // Greyscale background colour.
+    udl_element{"\\}00a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{0})},
+    udl_element{"\\}17a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{17})},
+    udl_element{"\\}22a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{22})},
+
+    // Extras after greyscale background colour take precedence.
+    udl_element{"\\}17\\}22a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{22})},
+    udl_element{"\\}22\\}17a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{17})},
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Adds a UDL (_ete = encoded text element) similar to the existing _ets (encoded text string) that performs the same function for a single element.  This resolves the issue where many elements are clumsily created using e.g. "\\U1B87"_ets[0].

Closes #189

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/274)
<!-- Reviewable:end -->
