### PR TITLE
Fix high and greyscale colour components.

### DIFF
--- a/include/terminalpp/ansi/graphics.hpp
+++ b/include/terminalpp/ansi/graphics.hpp
@@ -42,17 +42,19 @@ static constexpr byte colour_white   = 7;
 static constexpr byte colour_default = 9;
 
 // "High" colour constants.
-// High colours are the 216 RGB colours of the 256-colour palette,  where 
-// there are 6 possible values for each of R, G, B, and the colour 
+// High colours are the middle 216 RGB colours of the 256-colour palette,  
+// where there are 6 possible values for each of R, G, B, and the colour 
 // components are stored according to multiples of that number such that
-// the value of the colour is 36R + 6G + B.
+// the value of the colour is 36R + 6G + B.  This is then stored offset
+// 16.
+static constexpr byte high_colour_offset = 16;
 
 // ==========================================================================
 /// \brief Encode an RGB value.
 // ==========================================================================
 constexpr byte encode_high_components(byte red, byte green, byte blue)
 {
-    return red * 36 + green * 6 + blue;
+    return high_colour_offset + red * 36 + green * 6 + blue;
 }
 
 // ==========================================================================
@@ -60,7 +62,7 @@ constexpr byte encode_high_components(byte red, byte green, byte blue)
 // ==========================================================================
 constexpr byte high_red_component(byte value)
 {
-    return value / 36;
+    return (value - high_colour_offset) / 36;
 }
 
 // ==========================================================================
@@ -68,7 +70,7 @@ constexpr byte high_red_component(byte value)
 // ==========================================================================
 constexpr byte high_green_component(byte value)
 {
-    return (value % 36) / 6;
+    return ((value - high_colour_offset) % 36) / 6;
 }
 
 // ==========================================================================
@@ -76,7 +78,29 @@ constexpr byte high_green_component(byte value)
 // ==========================================================================
 constexpr byte high_blue_component(byte value)
 {
-    return value % 6;
+    return (value - high_colour_offset) % 6;
+}
+
+// "Greyscale" colour constants.
+// Greyscale colours are last 24 RGB colours of the 256-colour palette,
+// each of which represents a grey colour from black to white. This value
+// is then stored offset 232.
+static constexpr byte greyscale_colour_offset = 232;
+
+// ==========================================================================
+/// \brief Encode a greyscale value.
+// ==========================================================================
+constexpr byte encode_greyscale_component(byte grey)
+{
+    return greyscale_colour_offset + grey;
+}
+
+// ==========================================================================
+/// \brief Extract a greyscale value.
+// ==========================================================================
+constexpr byte greyscale_component(byte value)
+{
+    return value - greyscale_colour_offset;
 }
 
 }}}

--- a/include/terminalpp/colour.hpp
+++ b/include/terminalpp/colour.hpp
@@ -4,18 +4,7 @@
 #include <boost/operators.hpp>
 #include <iosfwd>
 
-// Implementor note:
-// Colour codes are represented as different classes:
-// low colour (original 16 ANSI colours, 8 with normal intensity and 8 with
-// high intensity), high colour (additional 216 RGB values) and 24 greyscale
-// colours.  Together, this makes exactly 256 colours, and so all of the 
-// colour objects map their values to a single byte.
 namespace terminalpp {
-
-namespace detail {
-    static constexpr byte high_colour_offset      = 16;
-    static constexpr byte greyscale_colour_offset = 232;
-}
 
 //* =========================================================================
 /// \brief Structure representing a normal ANSI 16-colour value
@@ -105,8 +94,7 @@ struct TERMINALPP_EXPORT high_colour
     //* =====================================================================
     constexpr high_colour(byte red, byte green, byte blue)
       : value_(
-          detail::high_colour_offset
-        + ansi::graphics::encode_high_components(red, green, blue))
+          ansi::graphics::encode_high_components(red, green, blue))
     {
     }
 
@@ -170,7 +158,7 @@ struct TERMINALPP_EXPORT greyscale_colour
     /// should be in the range 0-23.
     //* =====================================================================
     constexpr explicit greyscale_colour(byte shade)
-      : shade_(shade + detail::greyscale_colour_offset)
+      : shade_(ansi::graphics::encode_greyscale_component(shade))
     {
     }
 

--- a/src/colour.cpp
+++ b/src/colour.cpp
@@ -42,10 +42,9 @@ std::ostream &operator<<(std::ostream &out, low_colour const &col)
 // ==========================================================================
 std::ostream &operator<<(std::ostream &out, high_colour const &col)
 {
-    byte const value = col.value_ - detail::high_colour_offset;
-    byte const red   = ansi::graphics::high_red_component(value);
-    byte const green = ansi::graphics::high_green_component(value);
-    byte const blue  = ansi::graphics::high_blue_component(value);
+    byte const red   = ansi::graphics::high_red_component(col.value_);
+    byte const green = ansi::graphics::high_green_component(col.value_);
+    byte const blue  = ansi::graphics::high_blue_component(col.value_);
 
     return out << "#"
                << std::to_string(int(red))
@@ -59,7 +58,7 @@ std::ostream &operator<<(std::ostream &out, high_colour const &col)
 // ==========================================================================
 std::ostream &operator<<(std::ostream &out, greyscale_colour const &col)
 {
-    byte const shade = col.shade_ - detail::greyscale_colour_offset;
+    byte const shade = ansi::graphics::greyscale_component(col.shade_);
     return out << "#"
                << (shade < 10 ? "0" : "")
                << std::to_string(int(shade));

--- a/test/colour_test.cpp
+++ b/test/colour_test.cpp
@@ -87,7 +87,8 @@ static high_colour_string const high_colour_strings[] = {
     high_colour_string{ 3, 0, 0, "#300" },
     high_colour_string{ 0, 4, 0, "#040" },
     high_colour_string{ 0, 0, 5, "#005" },
-    high_colour_string{ 5, 3, 1, "#531" }
+    high_colour_string{ 5, 3, 1, "#531" },
+    high_colour_string{ 5, 5, 5, "#555" }
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Before, they did not take into account the offset into the ANSI colour space, now they do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/283)
<!-- Reviewable:end -->
