### PR TITLE
Add support for True Colour terminals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ export.hpp
 version.hpp
 CMakeSettings.json
 /.vs
+/.vscode
 /out
 **/build

--- a/include/terminalpp/colour.hpp
+++ b/include/terminalpp/colour.hpp
@@ -242,7 +242,7 @@ struct TERMINALPP_EXPORT colour
     //* =====================================================================
     enum class type : byte
     {
-        low, high, greyscale
+        low, high, greyscale, true_
     };
 
     //* =====================================================================
@@ -281,6 +281,15 @@ struct TERMINALPP_EXPORT colour
     }
 
     //* =====================================================================
+    /// \brief Constructs a colour with the passed true_colour value.
+    //* =====================================================================
+    constexpr colour(terminalpp::true_colour col)
+      : true_colour_(std::move(col)),
+        type_(type::true_)
+    {
+    }
+
+    //* =====================================================================
     /// \brief Copy constructor
     //* =====================================================================
     constexpr colour(terminalpp::graphics::colour col)
@@ -307,7 +316,7 @@ struct TERMINALPP_EXPORT colour
         terminalpp::low_colour low_colour_;
         terminalpp::high_colour high_colour_;
         terminalpp::greyscale_colour greyscale_colour_;
-        //terminalpp::true_colour true_colour_;
+        terminalpp::true_colour true_colour_;
     };
 
     type type_;

--- a/include/terminalpp/colour.hpp
+++ b/include/terminalpp/colour.hpp
@@ -203,6 +203,34 @@ TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, greyscale_colour const &col);
 
 //* =========================================================================
+/// \brief Structure representing the ~16 million colours codes of the
+/// true colour palette.
+//* =========================================================================
+struct TERMINALPP_EXPORT true_colour
+{
+    //* =====================================================================
+    /// \brief Constructor
+    //* =====================================================================
+    constexpr true_colour(byte const red, byte const green, byte const blue)
+      : red_(red),
+        green_(green),
+        blue_(blue)
+    {
+    }
+    
+    byte red_; 
+    byte green_; 
+    byte blue_;
+};
+
+//* =========================================================================
+/// \brief Streaming output operator for true_colours.  Prints the hex
+/// code of the colour (e.g. #AA00AA, etc.)
+//* =========================================================================
+TERMINALPP_EXPORT
+std::ostream &operator<<(std::ostream &out, true_colour const &col);
+
+//* =========================================================================
 /// \brief Structure representing a sum type of the available colour styles.
 //* =========================================================================
 struct TERMINALPP_EXPORT colour
@@ -279,6 +307,7 @@ struct TERMINALPP_EXPORT colour
         terminalpp::low_colour low_colour_;
         terminalpp::high_colour high_colour_;
         terminalpp::greyscale_colour greyscale_colour_;
+        //terminalpp::true_colour true_colour_;
     };
 
     type type_;

--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -224,6 +224,15 @@ void change_foreground_colour(
                 wc(to_bytes("38;5;{}"_format(
                     int(dest.greyscale_colour_.shade_)
                 )));
+                break;
+
+            case colour::type::true_:
+                wc(to_bytes("38;2;{};{};{}"_format(
+                    int(dest.true_colour_.red_),
+                    int(dest.true_colour_.green_),
+                    int(dest.true_colour_.blue_)
+                )));
+                break;
         }
     }
 }
@@ -267,6 +276,15 @@ void change_background_colour(
                 wc(to_bytes("48;5;{}"_format(
                     int(dest.greyscale_colour_.shade_)
                 )));
+                break;
+
+            case colour::type::true_:
+                wc(to_bytes("48;2;{};{};{}"_format(
+                    int(dest.true_colour_.red_),
+                    int(dest.true_colour_.green_),
+                    int(dest.true_colour_.blue_)
+                )));
+                break;
         }
     }
 }

--- a/src/colour.cpp
+++ b/src/colour.cpp
@@ -1,5 +1,7 @@
 #include "terminalpp/colour.hpp"
 #include <boost/range/algorithm/find_if.hpp>
+#include <boost/io/ios_state.hpp>
+#include <iomanip>
 #include <iostream>
 
 namespace terminalpp {
@@ -62,6 +64,24 @@ std::ostream &operator<<(std::ostream &out, greyscale_colour const &col)
     return out << "#"
                << (shade < 10 ? "0" : "")
                << std::to_string(int(shade));
+}
+
+// ==========================================================================
+// OPERATOR<<(STREAM, TRUE_COLOUR)
+// ==========================================================================
+std::ostream &operator<<(std::ostream &out, true_colour const &col)
+{
+    boost::io::ios_all_saver ias(out);
+    return out << "#"
+               << std::uppercase << std::hex << std::uppercase
+               << std::setw(2) << std::setfill('0')
+               << int(col.red_)
+               << std::uppercase << std::hex << std::uppercase
+               << std::setw(2) << std::setfill('0')
+               << int(col.green_)
+               << std::uppercase << std::hex << std::uppercase
+               << std::setw(2) << std::setfill('0')
+               << int(col.blue_);
 }
 
 // ==========================================================================

--- a/src/colour.cpp
+++ b/src/colour.cpp
@@ -93,14 +93,17 @@ std::ostream &operator<<(std::ostream &out, colour const &col)
     {
         default :
             // Fall-through
-        case colour::type::low :
+        case colour::type::low:
             return out << col.low_colour_;
 
-        case colour::type::high :
+        case colour::type::high:
             return out << col.high_colour_;
 
-        case colour::type::greyscale :
+        case colour::type::greyscale:
             return out << col.greyscale_colour_;
+
+        case colour::type::true_:
+            return out << col.true_colour_;
     }
 }
 

--- a/src/detail/element_udl.cpp
+++ b/src/detail/element_udl.cpp
@@ -36,6 +36,12 @@ enum class parser_state {
     bg_high_colour_2,
     bg_greyscale_colour_0,
     bg_greyscale_colour_1,
+    bg_true_colour_0,
+    bg_true_colour_1,
+    bg_true_colour_2,
+    bg_true_colour_3,
+    bg_true_colour_4,
+    bg_true_colour_5,
     utf8_0,
     utf8_1,
     utf8_2,
@@ -133,6 +139,47 @@ void parse_utf8_0(char const ch, parser_info &info, element &elem)
     info.state = parser_state::utf8_1;
 }
 
+void parse_bg_true_colour_5(char const ch, parser_info &info, element &elem)
+{
+    info.blue |= digit16_to_byte(ch);
+
+    elem.attribute_.background_colour_ = true_colour{
+        info.red, info.green, info.blue
+    };
+
+    info.state = parser_state::idle;
+}
+
+void parse_bg_true_colour_4(char const ch, parser_info &info, element &elem)
+{
+    info.blue = digit16_to_byte(ch) << 4;
+    info.state = parser_state::bg_true_colour_5;
+}
+
+void parse_bg_true_colour_3(char const ch, parser_info &info, element &elem)
+{
+    info.green |= digit16_to_byte(ch);
+    info.state = parser_state::bg_true_colour_4;
+}
+
+void parse_bg_true_colour_2(char const ch, parser_info &info, element &elem)
+{
+    info.green = digit16_to_byte(ch) << 4;
+    info.state = parser_state::bg_true_colour_3;
+}
+
+void parse_bg_true_colour_1(char const ch, parser_info &info, element &elem)
+{
+    info.red |= digit16_to_byte(ch);
+    info.state = parser_state::bg_true_colour_2;
+}
+
+void parse_bg_true_colour_0(char const ch, parser_info &info, element &elem)
+{
+    info.red = digit16_to_byte(ch) << 4;
+    info.state = parser_state::bg_true_colour_1;
+}
+
 void parse_bg_greyscale_1(char const ch, parser_info &info, element &elem)
 {
     byte const col = (info.greyscale * 10) + digit10_to_byte(ch);
@@ -188,10 +235,10 @@ void parse_fg_greyscale_0(char const ch, parser_info &info, element &elem)
     info.state = parser_state::fg_greyscale_colour_1;
 }
 
-void parse_gf_true_colour_5(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_5(char const ch, parser_info &info, element &elem)
 {
     info.blue |= digit16_to_byte(ch);
-    
+
     elem.attribute_.foreground_colour_ = true_colour{
         info.red, info.green, info.blue
     };
@@ -199,31 +246,31 @@ void parse_gf_true_colour_5(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_gf_true_colour_4(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_4(char const ch, parser_info &info, element &elem)
 {
     info.blue = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_5;
 }
 
-void parse_gf_true_colour_3(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_3(char const ch, parser_info &info, element &elem)
 {
     info.green |= digit16_to_byte(ch);
     info.state = parser_state::fg_true_colour_4;
 }
 
-void parse_gf_true_colour_2(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_2(char const ch, parser_info &info, element &elem)
 {
     info.green = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_3;
 }
 
-void parse_gf_true_colour_1(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_1(char const ch, parser_info &info, element &elem)
 {
     info.red |= digit16_to_byte(ch);
     info.state = parser_state::fg_true_colour_2;
 }
 
-void parse_gf_true_colour_0(char const ch, parser_info &info, element &elem)
+void parse_fg_true_colour_0(char const ch, parser_info &info, element &elem)
 {
     info.red = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_1;
@@ -398,12 +445,12 @@ void parse_escape(char const ch, parser_info &info, element &elem)
             info.state = parser_state::fg_high_colour_0;
             break;
 
-        case '(':
-            info.state = parser_state::fg_true_colour_0;
-            break;
-
         case '{':
             info.state = parser_state::fg_greyscale_colour_0;
+            break;
+
+        case '(':
+            info.state = parser_state::fg_true_colour_0;
             break;
 
         case ']':
@@ -416,6 +463,10 @@ void parse_escape(char const ch, parser_info &info, element &elem)
 
         case '}':
             info.state = parser_state::bg_greyscale_colour_0;
+            break;
+
+        case ')':
+            info.state = parser_state::bg_true_colour_0;
             break;
 
         case 'U':
@@ -487,18 +538,24 @@ element parse_element(gsl::cstring_span &text, element const &elem_base)
         parse_fg_high_colour_2,
         parse_fg_greyscale_0,
         parse_fg_greyscale_1,
-        parse_gf_true_colour_0,
-        parse_gf_true_colour_1,
-        parse_gf_true_colour_2,
-        parse_gf_true_colour_3,
-        parse_gf_true_colour_4,
-        parse_gf_true_colour_5,
+        parse_fg_true_colour_0,
+        parse_fg_true_colour_1,
+        parse_fg_true_colour_2,
+        parse_fg_true_colour_3,
+        parse_fg_true_colour_4,
+        parse_fg_true_colour_5,
         parse_bg_low_colour,
         parse_bg_high_colour_0,
         parse_bg_high_colour_1,
         parse_bg_high_colour_2,
         parse_bg_greyscale_0,
         parse_bg_greyscale_1,
+        parse_bg_true_colour_0,
+        parse_bg_true_colour_1,
+        parse_bg_true_colour_2,
+        parse_bg_true_colour_3,
+        parse_bg_true_colour_4,
+        parse_bg_true_colour_5,
         parse_utf8_0,
         parse_utf8_1,
         parse_utf8_2,

--- a/test/colour_test.cpp
+++ b/test/colour_test.cpp
@@ -200,12 +200,13 @@ TEST_P(colours_with_strings, can_be_streamed_to_an_ostream)
 }
 
 static colour_string const colour_strings[] = {
-    colour_string{ terminalpp::graphics::colour::red,     "red"   },
-    colour_string{ terminalpp::graphics::colour::green,   "green" },
-    colour_string{ terminalpp::high_colour(1, 2, 3),      "#123"  },
-    colour_string{ terminalpp::high_colour(5, 5, 4),      "#554"  },
-    colour_string{ terminalpp::greyscale_colour(0),       "#00"   },
-    colour_string{ terminalpp::greyscale_colour(21),      "#21"   },
+    colour_string{ terminalpp::graphics::colour::red,         "red"    },
+    colour_string{ terminalpp::graphics::colour::green,       "green"  },
+    colour_string{ terminalpp::high_colour(1, 2, 3),          "#123"   },
+    colour_string{ terminalpp::high_colour(5, 5, 4),          "#554"   },
+    colour_string{ terminalpp::greyscale_colour(0),           "#00"    },
+    colour_string{ terminalpp::greyscale_colour(21),          "#21"    },
+    colour_string{ terminalpp::true_colour(0xCD, 0x3B, 0x7A), "#CD3B7A"},
 };
 
 TEST(low_colours, can_be_inserted_into_an_unordered_set)

--- a/test/colour_test.cpp
+++ b/test/colour_test.cpp
@@ -134,6 +134,48 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(greyscale_strings)
 );
 
+using true_colour_string = std::tuple<
+    terminalpp::byte,    // red
+    terminalpp::byte,    // green
+    terminalpp::byte,    // blue
+    std::string          // expected output
+>;
+
+class true_colours_with_strings
+  : public testing::TestWithParam<true_colour_string>
+{
+};
+
+TEST_P(true_colours_with_strings, can_be_streamed_to_an_ostream)
+{
+    auto const &param = GetParam();
+    auto const &red   = std::get<0>(param);
+    auto const &green = std::get<1>(param);
+    auto const &blue  = std::get<2>(param);
+    auto const &expected_string = std::get<3>(param);
+
+    std::stringstream stream;
+    std::ostream &out = stream;
+
+    out << terminalpp::true_colour(red, green, blue);
+    ASSERT_EQ(expected_string, stream.str());
+}
+
+static true_colour_string const true_colour_strings[] = {
+    true_colour_string{ 0,   0,   0,   "#000000" },
+    true_colour_string{ 80,  0,   0,   "#500000" },
+    true_colour_string{ 0,   90,  0,   "#005A00" },
+    true_colour_string{ 0,   0,   100, "#000064" },
+    true_colour_string{ 40,  50,  60,  "#28323C" },
+    true_colour_string{ 255, 255, 255, "#FFFFFF" },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    true_colours_can_be_streamed_to_an_ostream,
+    true_colours_with_strings,
+    ValuesIn(true_colour_strings)
+);
+
 using colour_string = std::tuple<
     terminalpp::colour,
     std::string

--- a/test/colour_test.cpp
+++ b/test/colour_test.cpp
@@ -224,12 +224,18 @@ TEST(greyscale_colours, can_be_inserted_into_an_unordered_set)
     std::unordered_set<terminalpp::greyscale_colour> c { {} };
 }
 
+TEST(true_colours, can_be_inserted_into_an_unordered_set)
+{
+    std::unordered_set<terminalpp::true_colour> c { {} };
+}
+
 TEST(a_colour, can_be_inserted_into_an_unordered_set)
 {
     std::unordered_set<terminalpp::colour> c { 
         terminalpp::low_colour{},
         terminalpp::high_colour{},
-        terminalpp::greyscale_colour{} 
+        terminalpp::greyscale_colour{},
+        terminalpp::true_colour{}
     };
 }
 

--- a/test/element_test.cpp
+++ b/test/element_test.cpp
@@ -6,7 +6,7 @@ using testing::ValuesIn;
 
 TEST(element_test, elements_are_small)
 {
-    ASSERT_EQ(12, sizeof(terminalpp::element));
+    ASSERT_EQ(16, sizeof(terminalpp::element));
 }
 
 TEST(element_test, can_implicitly_construct_element_from_glyph)

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -211,6 +211,14 @@ static udl_element const udl_elements[] = {
     udl_element{"\\}17\\}22a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{22})},
     udl_element{"\\}22\\}17a"_ete, with_background_colour({'a'}, terminalpp::greyscale_colour{17})},
 
+    // True foreground colour.
+    udl_element{"\\)000000a"_ete, with_background_colour({'a'}, terminalpp::true_colour{0, 0, 0})},
+    udl_element{"\\)A917BEa"_ete, with_background_colour({'a'}, terminalpp::true_colour{0xA9, 0x17, 0xBE})},
+
+    // Extras after true background colour take precedence.
+    udl_element{"\\)A917BE\\)B37EA2a"_ete, with_background_colour({'a'}, terminalpp::true_colour{0xB3, 0x7E, 0xA2})},
+    udl_element{"\\)B37EA2\\)A917BEa"_ete, with_background_colour({'a'}, terminalpp::true_colour{0xA9, 0x17, 0xBE})},
+
     // Incomplete unicode character codes return a default character.
     udl_element{"\\U"_ete, terminalpp::element{}},
     udl_element{"\\U0"_ete, terminalpp::element{}},

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -175,6 +175,15 @@ static udl_element const udl_elements[] = {
     // Extras after greyscale foreground colour take precedence.
     udl_element{"\\{17\\{22a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{22})},
     udl_element{"\\{22\\{17a"_ete, with_foreground_colour({'a'}, terminalpp::greyscale_colour{17})},
+
+    // True foreground colour.
+    udl_element{"\\(000000a"_ete, with_foreground_colour({'a'}, terminalpp::true_colour{0, 0, 0})},
+    udl_element{"\\(A917BEa"_ete, with_foreground_colour({'a'}, terminalpp::true_colour{0xA9, 0x17, 0xBE})},
+
+    // Extras after true foreground colour take precedence.
+    udl_element{"\\(A917BE\\(B37EA2a"_ete, with_foreground_colour({'a'}, terminalpp::true_colour{0xB3, 0x7E, 0xA2})},
+    udl_element{"\\(B37EA2\\(A917BEa"_ete, with_foreground_colour({'a'}, terminalpp::true_colour{0xA9, 0x17, 0xBE})},
+
 //
     // Low background colour.
     udl_element{"\\]2a"_ete, with_background_colour({'a'}, terminalpp::palette::green)},

--- a/test/encoder_test.cpp
+++ b/test/encoder_test.cpp
@@ -250,6 +250,21 @@ TEST(string_encoder_test, greyscale_foreground_colour_code_encodes_colour)
         "\\{22abc");
 }
 
+TEST(string_encoder_test, true_foreground_colour_code_encodes_colour)
+{
+    terminalpp::attribute true_foreground_colour_attribute;
+    true_foreground_colour_attribute.foreground_colour_ =
+        terminalpp::true_colour(0xA7, 0xE9, 0x1C);
+
+    expect_encoding(
+        {
+            { 'a', true_foreground_colour_attribute },
+            { 'b', true_foreground_colour_attribute },
+            { 'c', true_foreground_colour_attribute },
+        },
+        "\\(A7E91Cabc");
+}
+
 TEST(string_encoder_test, low_background_colour_code_encodes_colour)
 {
     terminalpp::attribute low_background_colour_attribute;
@@ -293,6 +308,21 @@ TEST(string_encoder_test, greyscale_background_colour_code_encodes_colour)
             { 'c', greyscale_background_colour_attribute },
         },
         "\\}22abc");
+}
+
+TEST(string_encoder_test, true_background_colour_code_encodes_colour)
+{
+    terminalpp::attribute true_background_colour_attribute;
+    true_background_colour_attribute.background_colour_ =
+        terminalpp::true_colour(0xA7, 0xE9, 0x1C);
+
+    expect_encoding(
+        {
+            { 'a', true_background_colour_attribute },
+            { 'b', true_background_colour_attribute },
+            { 'c', true_background_colour_attribute },
+        },
+        "\\)A7E91Cabc");
 }
 
 TEST(string_encoder_test, unicode_codes_encode_unicode_text)

--- a/test/string_test.cpp
+++ b/test/string_test.cpp
@@ -357,6 +357,18 @@ INSTANTIATE_TEST_SUITE_P(
         string_relops_data{"\\{01a"_ets, "\\{01a"_ets, false, true,  true,  true,  false },
         string_relops_data{"\\{01a"_ets, "\\{02a"_ets, true,  true,  false, false, false },
 
+        //   o True colour
+        string_relops_data{"a"_ets,          "\\(010101a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\(010101a"_ets, "a"_ets,          false, false, false, true,  true  },
+        string_relops_data{"\\(010101a"_ets, "\\(010101a"_ets, false, true,  true,  true,  false },
+
+        string_relops_data{"\\(010101a"_ets, "\\(010102a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\(010101a"_ets, "\\(010201a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\(010101a"_ets, "\\(000101a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\(010101a"_ets, "\\(010001a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\(010101a"_ets, "\\(010100a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\(010001a"_ets, "\\(010100a"_ets, true,  true,  false, false, false },
+
         // o Background colour
         //   o Low colour
         string_relops_data{"a",         "\\]1a"_ets, false, false, false, true,  true  },
@@ -375,6 +387,18 @@ INSTANTIATE_TEST_SUITE_P(
         string_relops_data{"\\}01a"_ets, "a",          false, false, false, true,  true  },
         string_relops_data{"\\}01a"_ets, "\\}01a"_ets, false, true,  true,  true,  false },
         string_relops_data{"\\}01a"_ets, "\\}02a"_ets, true,  true,  false, false, false },
+
+        //   o True colour
+        string_relops_data{"a"_ets,          "\\)010101a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\)010101a"_ets, "a"_ets,          false, false, false, true,  true  },
+        string_relops_data{"\\)010101a"_ets, "\\)010101a"_ets, false, true,  true,  true,  false },
+
+        string_relops_data{"\\)010101a"_ets, "\\)010102a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\)010101a"_ets, "\\)010201a"_ets, true,  true,  false, false, false },
+        string_relops_data{"\\)010101a"_ets, "\\)000101a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\)010101a"_ets, "\\)010001a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\)010101a"_ets, "\\)010100a"_ets, false, false, false, true,  true  },
+        string_relops_data{"\\)010001a"_ets, "\\)010100a"_ets, true,  true,  false, false, false },
 
         // o Intensity
         string_relops_data{"a",         "\\i>a"_ets, false, false, false, true,  true  },

--- a/test/terminal_string_test.cpp
+++ b/test/terminal_string_test.cpp
@@ -86,11 +86,15 @@ static streaming_text_data const streaming_text_data_table[] = {
     streaming_text_data{ "\\u+abc"_ets, "\\u=de"_ets,    "\x1B[0mde"_tb },
 
     // Test foreground colour
-    streaming_text_data{ ""_ets,        "\\[2abc"_ets,   "\x1B[32mabc"_tb },
-    streaming_text_data{ ""_ets,        "\\[3abc"_ets,   "\x1B[33mabc"_tb },
-    streaming_text_data{ ""_ets,        "\\<510abc"_ets, "\x1B[38;5;202mabc"_tb },
-    streaming_text_data{ ""_ets,        "\\{12abc"_ets,  "\x1B[38;5;244mabc"_tb },
-    streaming_text_data{ ""_ets,        "\\[9abc"_ets,   "abc"_tb },
+    streaming_text_data{ ""_ets,        "\\[2abc"_ets,      "\x1B[32mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\[3abc"_ets,      "\x1B[33mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\<510abc"_ets,    "\x1B[38;5;202mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\{12abc"_ets,     "\x1B[38;5;244mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\[9abc"_ets,      "abc"_tb },
+    streaming_text_data{ ""_ets,        "\\(000000abc"_ets, "\x1B[38;2;0;0;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\(FF0000abc"_ets, "\x1B[38;2;255;0;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\(00FF00abc"_ets, "\x1B[38;2;0;255;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\(0000FFabc"_ets, "\x1B[38;2;0;0;255mabc"_tb },
 
     streaming_text_data{ 
         ""_ets,        
@@ -101,6 +105,10 @@ static streaming_text_data const streaming_text_data_table[] = {
     streaming_text_data{ ""_ets,        "\\]2abc"_ets,   "\x1B[42mabc"_tb },
     streaming_text_data{ ""_ets,        "\\>510abc"_ets, "\x1B[48;5;202mabc"_tb },
     streaming_text_data{ ""_ets,        "\\}12abc"_ets,  "\x1B[48;5;244mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\)000000abc"_ets, "\x1B[48;2;0;0;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\)FF0000abc"_ets, "\x1B[48;2;255;0;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\)00FF00abc"_ets, "\x1B[48;2;0;255;0mabc"_tb },
+    streaming_text_data{ ""_ets,        "\\)0000FFabc"_ets, "\x1B[48;2;0;0;255mabc"_tb },
 
     streaming_text_data{ 
         ""_ets,        


### PR DESCRIPTION
Adds a new colour type: true_colour.

A foreground colour can be built in the UDL from '(' followed by an RGB hexcode (e.g. "\(FF0000Hello!" for a bright red Hello!), and a background colour from ')' followed by an RGB hexcode.

Closes #284

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/285)
<!-- Reviewable:end -->
