### PR TITLE
Replaced usages of _format UDL.

### DIFF
--- a/include/terminalpp/detail/element_difference.hpp
+++ b/include/terminalpp/detail/element_difference.hpp
@@ -171,8 +171,6 @@ void change_effect(
     bool &change_appended,
     WriteContinuation &&wc)
 {
-    using namespace fmt::literals;
-
     if (source != dest)
     {
         if (std::exchange(change_appended, true))
@@ -181,7 +179,7 @@ void change_effect(
             wc(separator);
         }
 
-        wc(to_bytes("{}"_format(int(dest.value_))));
+        wc(to_bytes(fmt::format("{}", int(dest.value_))));
     }
 }
 
@@ -195,8 +193,6 @@ void change_foreground_colour(
     bool &change_appended,
     WriteContinuation &&wc)
 {
-    using namespace fmt::literals;
-
     if (source != dest)
     {
         if (std::exchange(change_appended, true))
@@ -208,26 +204,26 @@ void change_foreground_colour(
         switch (dest.type_)
         {
             case colour::type::low:
-                wc(to_bytes("{}"_format(
+                wc(to_bytes(fmt::format("{}",
                     int(dest.low_colour_.value_)
                   + ansi::graphics::foreground_colour_base
                 )));
                 break;
 
             case colour::type::high:
-                wc(to_bytes("38;5;{}"_format(
+                wc(to_bytes(fmt::format("38;5;{}",
                     int(dest.high_colour_.value_)
                 )));
                 break;
 
             case colour::type::greyscale:
-                wc(to_bytes("38;5;{}"_format(
+                wc(to_bytes(fmt::format("38;5;{}",
                     int(dest.greyscale_colour_.shade_)
                 )));
                 break;
 
             case colour::type::true_:
-                wc(to_bytes("38;2;{};{};{}"_format(
+                wc(to_bytes(fmt::format("38;2;{};{};{}",
                     int(dest.true_colour_.red_),
                     int(dest.true_colour_.green_),
                     int(dest.true_colour_.blue_)
@@ -247,8 +243,6 @@ void change_background_colour(
     bool &change_appended,
     WriteContinuation &&wc)
 {
-    using namespace fmt::literals;
-
     if (source != dest)
     {
         if (std::exchange(change_appended, true))
@@ -260,26 +254,26 @@ void change_background_colour(
         switch (dest.type_)
         {
             case colour::type::low:
-                wc(to_bytes("{}"_format(
+                wc(to_bytes(fmt::format("{}",
                     int(dest.low_colour_.value_)
                   + ansi::graphics::background_colour_base
                 )));
                 break;
 
             case colour::type::high:
-                wc(to_bytes("48;5;{}"_format(
+                wc(to_bytes(fmt::format("48;5;{}",
                     int(dest.high_colour_.value_)
                 )));
                 break;
 
             case colour::type::greyscale:
-                wc(to_bytes("48;5;{}"_format(
+                wc(to_bytes(fmt::format("48;5;{}",
                     int(dest.greyscale_colour_.shade_)
                 )));
                 break;
 
             case colour::type::true_:
-                wc(to_bytes("48;2;{};{};{}"_format(
+                wc(to_bytes(fmt::format("48;2;{};{};{}",
                     int(dest.true_colour_.red_),
                     int(dest.true_colour_.green_),
                     int(dest.true_colour_.blue_)

--- a/include/terminalpp/terminal.hpp
+++ b/include/terminalpp/terminal.hpp
@@ -180,20 +180,17 @@ private:
         behaviour const &beh,
         WriteContinuation &&cont) const
     {
-        using namespace terminalpp::literals;
-        using namespace fmt::literals;
-
         detail::csi(beh, cont);
 
         if (destination_.x_ != 0 || destination_.y_ != 0)
         {
             if (destination_.x_ == 0)
             {
-                cont(to_bytes("{}"_format(destination_.y_ + 1)));
+                cont(to_bytes(fmt::format("{}", destination_.y_ + 1)));
             }
             else
             {
-                cont(to_bytes("{};{}"_format(
+                cont(to_bytes(fmt::format("{};{}",
                     destination_.y_ + 1,
                     destination_.x_ + 1
                 )));
@@ -215,14 +212,11 @@ private:
         behaviour const &beh,
         WriteContinuation &&cont) const
     {
-        using namespace terminalpp::literals;
-        using namespace fmt::literals;
-
         detail::csi(beh, cont);
 
         if (destination_.x_ != 0)
         {
-            cont(to_bytes("{}"_format(destination_.x_ + 1)));
+            cont(to_bytes(fmt::format("{}", destination_.x_ + 1)));
         }
 
         static byte_storage const cursor_horizontal_absolute_suffix = {
@@ -241,14 +235,11 @@ private:
         coordinate_type const distance,
         WriteContinuation &&cont) const
     {
-        using namespace terminalpp::literals;
-        using namespace fmt::literals;
-
         detail::csi(beh, cont);
 
         if (distance != 1)
         {
-            cont(to_bytes("{}"_format(distance)));
+            cont(to_bytes(fmt::format("{}", distance)));
         }
 
         static byte_storage const cursor_up_suffix = {
@@ -267,14 +258,11 @@ private:
         coordinate_type const distance,
         WriteContinuation &&cont) const
     {
-        using namespace terminalpp::literals;
-        using namespace fmt::literals;
-
         detail::csi(beh, cont);
 
         if (distance != 1)
         {
-            cont(to_bytes("{}"_format(distance)));
+            cont(to_bytes(fmt::format("{}", distance)));
         }
 
         static byte_storage const cursor_down_suffix = {

--- a/test/expect_sequence.cpp
+++ b/test/expect_sequence.cpp
@@ -15,8 +15,7 @@ std::string escape(terminalpp::bytes const &text)
 
         if (!isprint(ch))
         {
-            using namespace fmt::literals;
-            result += "0x{:02X}"_format(int(ch));
+            result += fmt::format("0x{:02X}", int(ch));
         }
         else
         {


### PR DESCRIPTION
This has been marked deprecated in newer versions of fmtlib and
fails to build in Conan because of it.

Fixes #289

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/terminalpp/290)
<!-- Reviewable:end -->
