### PR TITLE
Element's _ete UDL is now constexpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ target_sources(terminalpp
         include/terminalpp/ansi/ss3.hpp
         include/terminalpp/detail/ascii.hpp
         include/terminalpp/detail/element_difference.hpp
+        include/terminalpp/detail/element_udl.hpp
         include/terminalpp/detail/export.hpp
         include/terminalpp/detail/lambda_visitor.hpp
         include/terminalpp/detail/parser.hpp
@@ -166,7 +167,6 @@ target_sources(terminalpp
         include/terminalpp/version.hpp
         include/terminalpp/virtual_key.hpp
 
-        src/detail/element_udl.cpp
         src/detail/parser.cpp
         src/detail/well_known_virtual_key.cpp
         src/attribute.cpp

--- a/include/terminalpp/detail/element_udl.hpp
+++ b/include/terminalpp/detail/element_udl.hpp
@@ -1,4 +1,3 @@
-#include "terminalpp/element.hpp"
 #include "terminalpp/character_set.hpp"
 #include "terminalpp/ansi/charset.hpp"
 
@@ -60,12 +59,12 @@ struct parser_info
     uint16_t utf8{0};
 };
 
-byte digit10_to_byte(char const ch)
+constexpr byte digit10_to_byte(char const ch)
 {
     return static_cast<byte>(ch - '0');
 }
 
-byte digit16_to_byte(char const ch)
+constexpr byte digit16_to_byte(char const ch)
 {
     return (ch >= '0' && ch <= '9') ? static_cast<byte>(ch - '0')
          : (ch >= 'a' && ch <= 'f') ? static_cast<byte>((ch - 'a') + 10)
@@ -73,9 +72,9 @@ byte digit16_to_byte(char const ch)
          : static_cast<byte>(0);
 }
 
-void parse_utf8_3(char const ch, parser_info &info, element &elem)
+constexpr void parse_utf8_3(char const ch, parser_info &info, element &elem)
 {
-    static constexpr long const maxima[] = {
+    constexpr long const maxima[] = {
         0x00007F,
         0x0007FF,
         0x00FFFF,
@@ -119,27 +118,27 @@ void parse_utf8_3(char const ch, parser_info &info, element &elem)
     info.state = parser_state::done;
 }
 
-void parse_utf8_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_utf8_2(char const ch, parser_info &info, element &elem)
 {
     info.utf8 *= 16;
     info.utf8 += digit16_to_byte(ch);
     info.state = parser_state::utf8_3;
 }
 
-void parse_utf8_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_utf8_1(char const ch, parser_info &info, element &elem)
 {
     info.utf8 *= 16;
     info.utf8 += digit16_to_byte(ch);
     info.state = parser_state::utf8_2;
 }
 
-void parse_utf8_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_utf8_0(char const ch, parser_info &info, element &elem)
 {
     info.utf8 = digit16_to_byte(ch);
     info.state = parser_state::utf8_1;
 }
 
-void parse_bg_true_colour_5(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_5(char const ch, parser_info &info, element &elem)
 {
     info.blue |= digit16_to_byte(ch);
 
@@ -150,50 +149,50 @@ void parse_bg_true_colour_5(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_bg_true_colour_4(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_4(char const ch, parser_info &info, element &elem)
 {
     info.blue = digit16_to_byte(ch) << 4;
     info.state = parser_state::bg_true_colour_5;
 }
 
-void parse_bg_true_colour_3(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_3(char const ch, parser_info &info, element &elem)
 {
     info.green |= digit16_to_byte(ch);
     info.state = parser_state::bg_true_colour_4;
 }
 
-void parse_bg_true_colour_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_2(char const ch, parser_info &info, element &elem)
 {
     info.green = digit16_to_byte(ch) << 4;
     info.state = parser_state::bg_true_colour_3;
 }
 
-void parse_bg_true_colour_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_1(char const ch, parser_info &info, element &elem)
 {
     info.red |= digit16_to_byte(ch);
     info.state = parser_state::bg_true_colour_2;
 }
 
-void parse_bg_true_colour_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_true_colour_0(char const ch, parser_info &info, element &elem)
 {
     info.red = digit16_to_byte(ch) << 4;
     info.state = parser_state::bg_true_colour_1;
 }
 
-void parse_bg_greyscale_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_greyscale_1(char const ch, parser_info &info, element &elem)
 {
     byte const col = (info.greyscale * 10) + digit10_to_byte(ch);
     elem.attribute_.background_colour_ = greyscale_colour(col);
     info.state = parser_state::idle;
 }
 
-void parse_bg_greyscale_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_greyscale_0(char const ch, parser_info &info, element &elem)
 {
     info.greyscale = digit10_to_byte(ch);
     info.state = parser_state::bg_greyscale_colour_1;
 }
 
-void parse_bg_high_colour_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_high_colour_2(char const ch, parser_info &info, element &elem)
 {
     auto const blue = digit10_to_byte(ch);
     elem.attribute_.background_colour_ = 
@@ -201,19 +200,19 @@ void parse_bg_high_colour_2(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_bg_high_colour_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_high_colour_1(char const ch, parser_info &info, element &elem)
 {
     info.green = digit10_to_byte(ch);
     info.state = parser_state::bg_high_colour_2;
 }
 
-void parse_bg_high_colour_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_high_colour_0(char const ch, parser_info &info, element &elem)
 {
     info.red = digit10_to_byte(ch);
     info.state = parser_state::bg_high_colour_1;
 }
 
-void parse_bg_low_colour(char const ch, parser_info &info, element &elem)
+constexpr void parse_bg_low_colour(char const ch, parser_info &info, element &elem)
 {
     auto const col_code = digit10_to_byte(ch);
     auto const col = static_cast<terminalpp::graphics::colour>(col_code);
@@ -222,20 +221,20 @@ void parse_bg_low_colour(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_fg_greyscale_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_greyscale_1(char const ch, parser_info &info, element &elem)
 {
     byte const col = (info.greyscale * 10) + digit10_to_byte(ch);
     elem.attribute_.foreground_colour_ = greyscale_colour(col);
     info.state = parser_state::idle;
 }
 
-void parse_fg_greyscale_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_greyscale_0(char const ch, parser_info &info, element &elem)
 {
     info.greyscale = digit10_to_byte(ch);
     info.state = parser_state::fg_greyscale_colour_1;
 }
 
-void parse_fg_true_colour_5(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_5(char const ch, parser_info &info, element &elem)
 {
     info.blue |= digit16_to_byte(ch);
 
@@ -246,37 +245,37 @@ void parse_fg_true_colour_5(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_fg_true_colour_4(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_4(char const ch, parser_info &info, element &elem)
 {
     info.blue = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_5;
 }
 
-void parse_fg_true_colour_3(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_3(char const ch, parser_info &info, element &elem)
 {
     info.green |= digit16_to_byte(ch);
     info.state = parser_state::fg_true_colour_4;
 }
 
-void parse_fg_true_colour_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_2(char const ch, parser_info &info, element &elem)
 {
     info.green = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_3;
 }
 
-void parse_fg_true_colour_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_1(char const ch, parser_info &info, element &elem)
 {
     info.red |= digit16_to_byte(ch);
     info.state = parser_state::fg_true_colour_2;
 }
 
-void parse_fg_true_colour_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_true_colour_0(char const ch, parser_info &info, element &elem)
 {
     info.red = digit16_to_byte(ch) << 4;
     info.state = parser_state::fg_true_colour_1;
 }
 
-void parse_fg_high_colour_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_high_colour_2(char const ch, parser_info &info, element &elem)
 {
     auto const blue = digit10_to_byte(ch);
     elem.attribute_.foreground_colour_ = 
@@ -284,19 +283,19 @@ void parse_fg_high_colour_2(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_fg_high_colour_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_high_colour_1(char const ch, parser_info &info, element &elem)
 {
     info.green = digit10_to_byte(ch);
     info.state = parser_state::fg_high_colour_2;
 }
 
-void parse_fg_high_colour_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_high_colour_0(char const ch, parser_info &info, element &elem)
 {
     info.red = digit10_to_byte(ch);
     info.state = parser_state::fg_high_colour_1;
 }
 
-void parse_fg_low_colour(char const ch, parser_info &info, element &elem)
+constexpr void parse_fg_low_colour(char const ch, parser_info &info, element &elem)
 {
     auto const col_code = digit10_to_byte(ch);
     auto const col = static_cast<terminalpp::graphics::colour>(col_code);
@@ -305,7 +304,7 @@ void parse_fg_low_colour(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_underlining(char const ch, parser_info &info, element &elem)
+constexpr void parse_underlining(char const ch, parser_info &info, element &elem)
 {
     switch(ch)
     {
@@ -325,7 +324,7 @@ void parse_underlining(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_polarity(char const ch, parser_info &info, element &elem)
+constexpr void parse_polarity(char const ch, parser_info &info, element &elem)
 {
     switch(ch)
     {
@@ -345,7 +344,7 @@ void parse_polarity(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_intensity(char const ch, parser_info &info, element &elem)
+constexpr void parse_intensity(char const ch, parser_info &info, element &elem)
 {
     switch (ch)
     {
@@ -365,7 +364,7 @@ void parse_intensity(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_charset_ext(char const ch, parser_info &info, element &elem)
+constexpr void parse_charset_ext(char const ch, parser_info &info, element &elem)
 {
     byte const charset_code[] = { ansi::charset_extender, static_cast<byte>(ch) };
     auto const charset = lookup_character_set(charset_code);
@@ -373,7 +372,7 @@ void parse_charset_ext(char const ch, parser_info &info, element &elem)
     info.state = parser_state::idle;
 }
 
-void parse_charset(char const ch, parser_info &info, element &elem)
+constexpr void parse_charset(char const ch, parser_info &info, element &elem)
 {
     switch (ch)
     {
@@ -392,7 +391,7 @@ void parse_charset(char const ch, parser_info &info, element &elem)
 
 }
 
-void parse_charcode_2(char const ch, parser_info &info, element &elem)
+constexpr void parse_charcode_2(char const ch, parser_info &info, element &elem)
 {
     info.charcode *= 10;
     info.charcode += digit10_to_byte(ch);
@@ -400,20 +399,20 @@ void parse_charcode_2(char const ch, parser_info &info, element &elem)
     info.state = parser_state::done;
 }
 
-void parse_charcode_1(char const ch, parser_info &info, element &elem)
+constexpr void parse_charcode_1(char const ch, parser_info &info, element &elem)
 {
     info.charcode *= 10;
     info.charcode += digit10_to_byte(ch);
     info.state = parser_state::charcode_2;
 }
 
-void parse_charcode_0(char const ch, parser_info &info, element &elem)
+constexpr void parse_charcode_0(char const ch, parser_info &info, element &elem)
 {
     info.charcode = digit10_to_byte(ch);
     info.state = parser_state::charcode_1;
 }
 
-void parse_escape(char const ch, parser_info &info, element &elem)
+constexpr void parse_escape(char const ch, parser_info &info, element &elem)
 {
     switch (ch)
     {
@@ -485,7 +484,7 @@ void parse_escape(char const ch, parser_info &info, element &elem)
     }
 }
 
-void parse_idle(char const ch, parser_info &info, element &elem)
+constexpr void parse_idle(char const ch, parser_info &info, element &elem)
 {
     switch (ch)
     {
@@ -500,7 +499,7 @@ void parse_idle(char const ch, parser_info &info, element &elem)
     }
 }
 
-element element_with_base(element const &elem_base)
+constexpr element element_with_base(element const &elem_base)
 {
     element result = elem_base;
     result.glyph_.charset_ = 
@@ -514,7 +513,7 @@ element element_with_base(element const &elem_base)
 
 }
 
-element parse_element(gsl::cstring_span &text, element const &elem_base)
+constexpr element parse_element(gsl::cstring_span &text, element const &elem_base)
 {
     auto info = parser_info{};
     auto elem = element_with_base(elem_base);

--- a/include/terminalpp/element.hpp
+++ b/include/terminalpp/element.hpp
@@ -81,17 +81,18 @@ constexpr bool operator==(element const &lhs, element const &rhs)
 TERMINALPP_EXPORT
 std::ostream &operator<<(std::ostream &out, element const &elem);
 
-namespace detail {
-TERMINALPP_EXPORT
-element parse_element(gsl::cstring_span &text, element const &elem_base = ' ');
 }
 
+#include "terminalpp/detail/element_udl.hpp"
+
+namespace terminalpp {
 inline namespace literals {
 
-inline element operator ""_ete(char const *text, std::size_t len)
+inline constexpr element operator ""_ete(char const *text, std::size_t len)
 {
     gsl::cstring_span data(text, len);
-    return detail::parse_element(data);
+    element elem;
+    return detail::parse_element(data, elem);
 }
 
 }}

--- a/src/character_set.cpp
+++ b/src/character_set.cpp
@@ -1,7 +1,5 @@
 #include "terminalpp/character_set.hpp"
-#include "terminalpp/ansi/charset.hpp"
 #include <boost/range/algorithm/find_if.hpp>
-#include <boost/range/algorithm_ext/insert.hpp>
 #include <iostream>
 
 namespace terminalpp {
@@ -31,118 +29,6 @@ static constexpr struct {
     { terminalpp::charset::sco,                        "sco"    },
     { terminalpp::charset::utf8,                       "u"      },
 };
-
-static constexpr std::pair<charset, byte const (&)[1]> const charset_map[] =
-{
-    { charset::us_ascii,          ansi::charset_us_ascii            },
-    { charset::sco,               ansi::charset_sco                 },
-    { charset::dec,               ansi::charset_dec                 },
-    { charset::dec_supplementary, ansi::charset_dec_supplementary   },
-    { charset::dec_technical,     ansi::charset_dec_technical       },
-    { charset::uk,                ansi::charset_uk                  },
-    { charset::dutch,             ansi::charset_dutch               },
-    { charset::finnish,           ansi::charset_finnish             },
-    { charset::finnish,           ansi::charset_finnish_alt         },
-    { charset::french,            ansi::charset_french              },
-    { charset::french,            ansi::charset_french_alt          },
-    { charset::french_canadian,   ansi::charset_french_canadian     },
-    { charset::french_canadian,   ansi::charset_french_canadian_alt },
-    { charset::german,            ansi::charset_german              },
-    { charset::italian,           ansi::charset_italian             },
-    { charset::danish,            ansi::charset_danish              },
-    { charset::danish,            ansi::charset_danish_alt_1        },
-    { charset::danish,            ansi::charset_danish_alt_2        },
-    { charset::spanish,           ansi::charset_spanish             },
-    { charset::swedish,           ansi::charset_swedish             },
-    { charset::swedish,           ansi::charset_swedish_alt         },
-    { charset::swiss,             ansi::charset_swiss               },
-};
-
-static constexpr std::pair<charset, byte const (&)[2]> const extended_charset_map[] =
-{
-    { charset::dec_supplementary_graphics, ansi::charset_dec_supplementary_gr },
-    { charset::portuguese,                 ansi::charset_portuguese           },
-};
-
-// ==========================================================================
-// LOOKUP_CHARACTER_SET
-// ==========================================================================
-boost::optional<character_set> lookup_character_set(bytes code)
-{
-    const auto len = code.size();
-
-    if (len == 0)
-    {
-        return {};
-    }
-
-    if (code[0] == ansi::charset_extender)
-    {
-        if (len > 1)
-        {
-            for (auto &&mapping : extended_charset_map)
-            {
-                if (code[1] == mapping.second[1])
-                {
-                    return character_set(mapping.first);
-                }
-            }
-        }
-    }
-    else
-    {
-        for (auto &&mapping : charset_map)
-        {
-            if (code[0] == mapping.second[0])
-            {
-                return character_set(mapping.first);
-            }
-        }
-    }
-
-    return {};
-}
-
-// ==========================================================================
-// ENCODE_CHARACTER_SET
-// ==========================================================================
-byte_storage encode_character_set(character_set const &set)
-{
-    byte_storage result;
-
-    auto const mapped_charset_matches_set = 
-        [&set](auto const &mapping)
-        {
-            return mapping.first == set;
-        };
-
-    auto const charset_entry = boost::find_if(
-        charset_map,
-        mapped_charset_matches_set);
-
-    if (charset_entry != std::cend(charset_map))
-    {
-        boost::insert(result, result.end(), charset_entry->second);
-    }
-    else
-    {
-        auto const extended_charset_entry = boost::find_if(
-            extended_charset_map,
-            mapped_charset_matches_set);
-
-        if (extended_charset_entry != std::cend(extended_charset_map))
-        {
-            boost::insert(result, result.end(), extended_charset_entry->second);
-        }
-        else
-        {
-            // If the character set is an unknown, fall back to US ASCII.
-            result = encode_character_set(character_set(charset::us_ascii));
-        }
-    }
-
-    return result;
-}
 
 // ==========================================================================
 // OPERATOR<<(STREAM, CHARACTER_SET)

--- a/test/element_udl_test.cpp
+++ b/test/element_udl_test.cpp
@@ -28,37 +28,37 @@ TEST_P(element_udl_test, parse_udl)
 }
 
 namespace {
-terminalpp::element with_charset(terminalpp::element elem, terminalpp::charset charset)
+constexpr terminalpp::element with_charset(terminalpp::element elem, terminalpp::charset charset)
 {
     elem.glyph_.charset_ = charset;
     return elem;
 }
 
-terminalpp::element with_intensity(terminalpp::element elem, terminalpp::graphics::intensity intensity)
+constexpr terminalpp::element with_intensity(terminalpp::element elem, terminalpp::graphics::intensity intensity)
 {
     elem.attribute_.intensity_ = intensity;
     return elem;
 }
 
-terminalpp::element with_polarity(terminalpp::element elem, terminalpp::graphics::polarity polarity)
+constexpr terminalpp::element with_polarity(terminalpp::element elem, terminalpp::graphics::polarity polarity)
 {
     elem.attribute_.polarity_ = polarity;
     return elem;
 }
 
-terminalpp::element with_underlining(terminalpp::element elem, terminalpp::graphics::underlining underlining)
+constexpr terminalpp::element with_underlining(terminalpp::element elem, terminalpp::graphics::underlining underlining)
 {
     elem.attribute_.underlining_ = underlining;
     return elem;
 }
 
-terminalpp::element with_foreground_colour(terminalpp::element elem, terminalpp::colour col)
+constexpr terminalpp::element with_foreground_colour(terminalpp::element elem, terminalpp::colour col)
 {
     elem.attribute_.foreground_colour_ = col;
     return elem;
 }
 
-terminalpp::element with_background_colour(terminalpp::element elem, terminalpp::colour col)
+constexpr terminalpp::element with_background_colour(terminalpp::element elem, terminalpp::colour col)
 {
     elem.attribute_.background_colour_ = col;
     return elem;
@@ -66,7 +66,7 @@ terminalpp::element with_background_colour(terminalpp::element elem, terminalpp:
 
 }
 
-static udl_element const udl_elements[] = {
+static constexpr udl_element const udl_elements[] = {
     // Empty string returns default element.
     udl_element{""_ete, terminalpp::element{}},
 


### PR DESCRIPTION
As a proof of concept, this drops ~30KB from the optimized test executable.